### PR TITLE
Enable 2nd order check

### DIFF
--- a/test/2nd_order_check.jl
+++ b/test/2nd_order_check.jl
@@ -1,53 +1,53 @@
 using DiffEqOperators, Test, LinearAlgebra
 
 @testset "Second Order Value Check" begin
-  ord = 2               # Order of approximation
-  Δx = 0.025π
-  N = Int(2*(π/Δx)) -2
-  x = -π:Δx:π-Δx
-  D1  = CenteredDifference(1,ord,Δx,N,:periodic,:periodic);    # 1nd Derivative
-  D2  = CenteredDifference(2,ord,Δx,N,:periodic,:periodic);    # 2nd Derivative
+    ord = 2               # Order of approximation
+    Δx = 0.025π
+    N = Int(2*(π/Δx)) -2
+    x = -π:Δx:π-Δx
+    D1  = CenteredDifference(1,ord,Δx,N,:periodic,:periodic);    # 1nd Derivative
+    D2  = CenteredDifference(2,ord,Δx,N,:periodic,:periodic);    # 2nd Derivative
 
-  u0 = cos.(x)
-  du_true = -cos.(x)
+    u0 = cos.(x)
+    du_true = -cos.(x)
 
-  M = Matrix(Tridiagonal([1.0 for i in 1:N+1],[-2.0 for i in 1:N+2],[1.0 for i in 1:N+1]))
-  # Do the reflections, different for x and y operators
-  M[end,1] = 1.0
-  M[1,end] = 1.0
-  M = M/(Δx^2)
-  @test M*u0 ≈ D2*u0
+    M = Matrix(Tridiagonal([1.0 for i in 1:N+1],[-2.0 for i in 1:N+2],[1.0 for i in 1:N+1]))
+    # Do the reflections, different for x and y operators
+    M[end,1] = 1.0
+    M[1,end] = 1.0
+    M = M/(Δx^2)
+    @test M*u0 ≈ D2*u0
 
-  A = zeros(size(M))
-  for i in 1:N+2, j in 1:N+2
-      i == j && (A[i,j] = -0.5)
-      abs(i - j) == 2 && (A[i,j] = 0.25)
-  end
-  A[end-1,1] = 0.25
-  A[end,2] = 0.25
-  A[1,end-1] = 0.25
-  A[2,end] = 0.25
-  A = A/(Δx^2)
+    A = zeros(size(M))
+    for i in 1:N+2, j in 1:N+2
+        i == j && (A[i,j] = -0.5)
+        abs(i - j) == 2 && (A[i,j] = 0.25)
+    end
+    A[end-1,1] = 0.25
+    A[end,2] = 0.25
+    A[1,end-1] = 0.25
+    A[2,end] = 0.25
+    A = A/(Δx^2)
 
-  @test A*u0 ≈ D1*(D1*u0)
+    @test A*u0 ≈ D1*(D1*u0)
 
-  κ(x) = 1.0
-  tmp1 = similar(x)
-  tmp2 = similar(x)
-  function f(t,u,du)
-      mul!(tmp1,  D1, u)
-      @. tmp2 = κ(x)*tmp1
-      mul!(du,D1,tmp2)
-  end
+    κ(x) = 1.0
+    tmp1 = similar(x)
+    tmp2 = similar(x)
+    function f(t,u,du)
+        mul!(tmp1,  D1, u)
+        @. tmp2 = κ(x)*tmp1
+        mul!(du,D1,tmp2)
+    end
 
-  du = similar(u0)
-  f(0,u0,du)
-  du ≈ A*u0
+    du = similar(u0)
+    f(0,u0,du)
+    du ≈ A*u0
 
-  error = du_true - du
-  du2 = D2*u0
-  error2 = du_true - du2
+    error = du_true - du
+    du2 = D2*u0
+    error2 = du_true - du2
 
-  @test maximum(error) < 0.004
-  @test maximum(error2) < 0.001
+    @test maximum(error) < 0.004
+    @test maximum(error2) < 0.001
 end

--- a/test/2nd_order_check.jl
+++ b/test/2nd_order_check.jl
@@ -2,24 +2,30 @@ using DiffEqOperators, Test, LinearAlgebra
 
 @testset "Second Order Value Check" begin
     ord = 2               # Order of approximation
-    Δx = 0.025π
-    N = Int(2*(π/Δx)) -2
-    x = -π:Δx:π-Δx
-    D1  = CenteredDifference(1,ord,Δx,N,:periodic,:periodic);    # 1nd Derivative
-    D2  = CenteredDifference(2,ord,Δx,N,:periodic,:periodic);    # 2nd Derivative
+    h = 0.025π
+    N = Int(2*(π/h))
+    x = -π:h:π-h
+    L1  = CenteredDifference(1,ord,h,N);
+    L2 = CenteredDifference(2,ord,h,N);
+
+    Q = PeriodicBC(Float64)
 
     u0 = cos.(x)
     du_true = -cos.(x)
 
-    M = Matrix(Tridiagonal([1.0 for i in 1:N+1],[-2.0 for i in 1:N+2],[1.0 for i in 1:N+1]))
-    # Do the reflections, different for x and y operators
+    # Explicit stencil for L2
+    M = Matrix(Tridiagonal([1.0 for i in 1:N-1],
+                           [-2.0 for i in 1:N],
+                           [1.0 for i in 1:N-1]))
+
+    # Insert periodic BC
     M[end,1] = 1.0
     M[1,end] = 1.0
-    M = M/(Δx^2)
-    @test M*u0 ≈ D2*u0
+    M = M/(h^2)
+    @test M*u0 ≈ L2*Q*u0
 
     A = zeros(size(M))
-    for i in 1:N+2, j in 1:N+2
+    for i in 1:N, j in 1:N
         i == j && (A[i,j] = -0.5)
         abs(i - j) == 2 && (A[i,j] = 0.25)
     end
@@ -27,17 +33,17 @@ using DiffEqOperators, Test, LinearAlgebra
     A[end,2] = 0.25
     A[1,end-1] = 0.25
     A[2,end] = 0.25
-    A = A/(Δx^2)
+    A = A/(h^2)
 
-    @test A*u0 ≈ D1*(D1*u0)
+    @test A*u0 ≈ L1*Q*(L1*Q*u0)
 
     κ(x) = 1.0
     tmp1 = similar(x)
     tmp2 = similar(x)
     function f(t,u,du)
-        mul!(tmp1,  D1, u)
+        mul!(tmp1,L1,Q*u)
         @. tmp2 = κ(x)*tmp1
-        mul!(du,D1,tmp2)
+        mul!(du,L1,Q*tmp2)
     end
 
     du = similar(u0)
@@ -45,7 +51,7 @@ using DiffEqOperators, Test, LinearAlgebra
     du ≈ A*u0
 
     error = du_true - du
-    du2 = D2*u0
+    du2 = L2*Q*u0
     error2 = du_true - du2
 
     @test maximum(error) < 0.004

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ if GROUP == "All" || GROUP == "Interface"
     @time @safetestset "Validate and Compare Generic Operators" begin include("generic_operator_validation.jl") end
     @time @safetestset "Validate Boundary Padded Array Concretization" begin include("boundary_padded_array.jl") end
     @time @safetestset "Validate Higher Dimensional Boundary Extension" begin include("MultiDimBC_test.jl") end
-    #@time @safetestset "2nd order check" begin include("2nd_order_check.jl") end
+    @time @safetestset "2nd order check" begin include("2nd_order_check.jl") end
     #@time @safetestset "KdV" begin include("KdV.jl") end # KdV times out and all fails
     #@time @safetestset "Heat Equation" begin include("heat_eqn.jl") end
     @time @safetestset "Matrix-Free Operators" begin include("matrixfree.jl") end


### PR DESCRIPTION
The "2nd_order_check" test set was working (after some small tweaks), so I re-enabled it. Changes are in this commit: https://github.com/SciML/DiffEqOperators.jl/commit/616e37846de3d6cc3673fb46353bc0e2d6f66f8b