### PR TITLE
[WIP] First steps in PDE autodiscretization.

### DIFF
--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -9,23 +9,45 @@ MOLFiniteDifference(args...;order=2) = MOLFiniteDifference(args,order)
 
 # Get boundary conditions from an array
 function get_bcs(bcs,tdomain,domain)
-    u_t0 = 0.0
-    u_x0 = 0.0
-    u_x1 = 0.0
+    lhs_deriv_depvars_bcs = Dict()
     n = size(bcs,1)
     for i = 1:n
-        if bcs[i].lhs.op isa Variable
-            if isequal(bcs[i].lhs.args[1],tdomain.lower) # u(t=0,x)
-                u_t0 = Expr(bcs[i].rhs)
+        var = bcs[i].lhs.op
+        if var isa Variable
+            if !haskey(lhs_deriv_depvars_bcs,var)
+                lhs_deriv_depvars_bcs[var] = Array{Expr}(undef,3)
+            end
+            if isequal(bcs[i].lhs.args[1],tdomain.lower) # u(t=0,x) 
+                lhs_deriv_depvars_bcs[var][1] = Expr(bcs[i].rhs)
             elseif isequal(bcs[i].lhs.args[2],domain.lower) # u(t,x=x_init)
-                u_x0 = bcs[i].rhs.value
+                lhs_deriv_depvars_bcs[var][2] = :(var=$(bcs[i].rhs.value))
             elseif isequal(bcs[i].lhs.args[2],domain.upper) # u(t,x=x_final)
-                u_x1 = bcs[i].rhs.value
+                lhs_deriv_depvars_bcs[var][3] = :(var=$(bcs[i].rhs.value))
             end
         end
     end
-    return (u_t0,u_x0,u_x1)
+    return lhs_deriv_depvars_bcs
 end
+
+# # Get boundary conditions from an array
+# function get_bcs(bcs,tdomain,domain)
+#     u_t0 = 0.0
+#     u_x0 = 0.0
+#     u_x1 = 0.0
+#     n = size(bcs,1)
+#     for i = 1:n
+#         if bcs[i].lhs.op isa Variable
+#             if isequal(bcs[i].lhs.args[1],tdomain.lower) # u(t=0,x)
+#                 u_t0 = Expr(bcs[i].rhs)
+#             elseif isequal(bcs[i].lhs.args[2],domain.lower) # u(t,x=x_init)
+#                 u_x0 = bcs[i].rhs.value
+#             elseif isequal(bcs[i].lhs.args[2],domain.upper) # u(t,x=x_final)
+#                 u_x1 = bcs[i].rhs.value
+#             end
+#         end
+#     end
+#     return (u_t0,u_x0,u_x1)
+# end
 
 # Recursively traverses the input expression (rhs), replacing derivatives by
 # finite difference schemes. It returns a time dependent expression (expr)
@@ -33,13 +55,13 @@ end
 # Note: 'non-derived' dependent variables are inserted into the diff. equations
 #       E.g. Dx(u(t,x))=v(t,x)*Dx(u(t,x)), v(t,x)=t*x
 #            =>  Dx(u(t,x))=t*x*Dx(u(t,x))
-function discretize_2(input,iv,grade,order,dx,m,nonderiv_depvars)
+function discretize_2(input,iv,grade,order,dx,m,lhs_nonderiv_depvars)
     if input isa ModelingToolkit.Constant
         return :($input.value)
     elseif input isa Operation
         if input.op isa Variable
-            if haskey(nonderiv_depvars,input.op)
-                x = nonderiv_depvars[input.op]
+            if haskey(lhs_nonderiv_depvars,input.op)
+                x = lhs_nonderiv_depvars[input.op]
                 if x isa ModelingToolkit.Constant
                     expr = :($x.value)
                 else
@@ -50,33 +72,35 @@ function discretize_2(input,iv,grade,order,dx,m,nonderiv_depvars)
                 # TODO: the discretization order should not be the same for
                 #       first derivatives and second derivarives
                 expr = :((u[i]-u[i-1])/$dx)
-            else
+            elseif grade == 2
                 expr = :((u[i+1]-2.0*u[i]+u[i-1])/($dx*$dx))
+            else
+                expr = :(u[i])
             end
             return expr
         elseif input.op isa Differential
             grade += 1
-            return discretize_2(input.args[1],input.op.x,grade,order,dx,m,nonderiv_depvars)
+            return discretize_2(input.args[1],input.op.x,grade,order,dx,m,lhs_nonderiv_depvars)
         elseif input.op isa typeof(*)
-            expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
-            expr2 = discretize_2(input.args[2],iv,grade,order,dx,m,nonderiv_depvars)
+            expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,lhs_nonderiv_depvars)
+            expr2 = discretize_2(input.args[2],iv,grade,order,dx,m,lhs_nonderiv_depvars)
             return Expr(:call,:*,expr1,expr2)
         elseif input.op isa typeof(-)
             if size(input.args,1) == 2
-                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
-                expr2 = discretize_2(input.args[2],iv,grade,order,dx,m,nonderiv_depvars)
+                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,lhs_nonderiv_depvars)
+                expr2 = discretize_2(input.args[2],iv,grade,order,dx,m,lhs_nonderiv_depvars)
                 return Expr(:call,:-,expr1,expr2)
             else #if size(input.args,1) == 1
-                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
+                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,lhs_nonderiv_depvars)
                 return Expr(:call,:*,:(-1),expr1)
             end
         elseif input.op isa typeof(+)
             if size(input.args,1) == 2
-                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
-                expr2 = discretize_2(input.args[2],iv,grade,order,dx,m,nonderiv_depvars)
+                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,lhs_nonderiv_depvars)
+                expr2 = discretize_2(input.args[2],iv,grade,order,dx,m,lhs_nonderiv_depvars)
                 return Expr(:call,:+,expr1,expr2)
             else #if size(input.args,1) == 1
-                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
+                expr1 = discretize_2(input.args[1],iv,grade,order,dx,m,lhs_nonderiv_depvars)
                 return Expr(expr1)
             end
         end
@@ -133,51 +157,69 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
     # in the ODE function (f)
 
     # TODO: improve the code below using index arrays instead of Dicts?
-    nonderiv_depvars = Dict()
-    deriv_depvars = Dict()
+    lhs_nonderiv_depvars = Dict()
+    lhs_deriv_depvars = Dict()
     discretization = Dict()
     # if there is only one equation
     if pdesys.eq isa Equation
-        x = pdesys.eq.lhs.op
-        discretization[x] = discretize_2(pdesys.eq.rhs,0,0,order,dx[1],xx[1],Dict())
+        var = pdesys.eq.lhs.args[1].op
+        discretization[var] = discretize_2(pdesys.eq.rhs,0,0,order,dx[1],xx[1],Dict())
     # if there are many equations (pdesys.eq isa Array)
     else
         # Store 'non-derived' dependent variables (e.g. v(t,x)=t*x)
-        # and 'derived' dependent variables (e.g. Dxx(u(t,x)))
+        # and 'derived' dependent variables (e.g. Dt(u(t,x)))
         n_eqs = size(pdesys.eq,1)
         for i = 1:n_eqs
-            x = pdesys.eq[i].lhs.op
-            if x isa Variable
-                nonderiv_depvars[x] = pdesys.eq[i].rhs
-            else #x isa Differential
-                deriv_depvars[x] = pdesys.eq[i].rhs
+            input = pdesys.eq[i].lhs
+            if input.op isa Variable
+                var = input.op
+                lhs_nonderiv_depvars[var] = pdesys.eq[i].rhs
+            else #var isa Differential
+                var = input.args[1].op
+                lhs_deriv_depvars[var] = pdesys.eq[i].rhs
             end
         end
 
         # Calc. coeff. matrix for each differential equation
-        for (x,rhs) in deriv_depvars
-            discretization[x] = discretize_2(rhs,0,0,order,dx[1],xx[1],nonderiv_depvars)
+        for (var,rhs) in lhs_deriv_depvars
+            discretization[var] = discretize_2(rhs,0,0,order,dx[1],xx[1],lhs_nonderiv_depvars)
         end
     end
 
     ### Get boundary conditions ################################################
     # TODO: generalize to N equations
-    (u_t0,u_x0,u_x1) = get_bcs(pdesys.bcs,tdomain,domain[1])
-    # TODO: is there a better way to use eval here?
+    lhs_deriv_depvars_bcs = get_bcs(pdesys.bcs,tdomain,domain[1])
     t = 0.0
-    g = eval(:((x,t) -> $u_t0))
     interior = domain[1].lower+dx[1]:dx[1]:domain[1].upper-dx[1]
+    u0 = Array{Float64}(undef,length(interior),length(discretization))
+    Q = Array{RobinBC}(undef,length(discretization))
+    
+    i = 1
+    for var in keys(discretization)
+        bcs = lhs_deriv_depvars_bcs[var]
 
-    u0 = @eval $g.($interior,$t)
-    Q = DirichletBC(u_x0,u_x1)
+        g = eval(:((x,t) -> $(bcs[1])))
+        u0[:,i] = @eval $g.($interior,$t)
+        
+        u_x0 = eval(bcs[2])
+        u_x1 = eval(bcs[3])
+        Q[i] = DirichletBC(u_x0,u_x1)
+
+        i = i+1
+
+    end
+
 
     ### Define the discretized PDE as an ODE function ##########################
     function f(du,u,p,t)
-        for d in values(discretization)
-            g = eval(:((u,t,i) -> $d))
+        j = 1
+        for disc in values(discretization)
+            g = eval(:((u,t,i) -> $disc))
+            Qu = Q[j]*u[:,j]
             for i = 1:xx[1]
-                du[i] = @eval $g($(Q*u),$t,$(i+1))
+                du[i,j] = @eval $g($(Qu),$t,$(i+1))
             end
+            j = j+1
         end
     end
 

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -2,10 +2,10 @@
 
 # Method of lines discretization scheme
 struct MOLFiniteDifference{T} <: DiffEqBase.AbstractDiscretization
-  dxs::T
-  order::Int
+    dxs::T
+    order::Int
+    MOLFiniteDifference(args...;order=2) = new{typeof(args[1])}(args[1],order)
 end
-MOLFiniteDifference(args...;order=2) = MOLFiniteDifference(args,order)
 
 # Get boundary conditions from an array
 function get_bcs(bcs,tdomain,domain)
@@ -132,11 +132,7 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
     xx = []
     for i = 1:no_iv-1
         domain = vcat(domain,pdesys.domain[i+1].domain)
-        if discretization.dxs isa Float64
-            dx = vcat(dx,discretization.dxs)
-        else
-            dx = vcat(dx,discretization.dxs[1])
-        end
+        dx = vcat(dx,discretization.dxs)
         X = vcat(X,domain[i].lower:dx[i]:domain[i].upper)
         xx = vcat(xx,size(X,1)-2)
     end

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -45,13 +45,10 @@ function calc_coeff_mat(input,iv,grade,order,dx,m)
             return L
         elseif input.op isa Differential
             grade += 1
-            calc_coeff_mat(input.args[1],input.op.x,grade,order,dx,m)
+            return calc_coeff_mat(input.args[1],input.op.x,grade,order,dx,m)
         elseif input.op isa typeof(*)
-            n = size(input.args)[1]
-            output = calc_coeff_mat(input.args[1],iv,grade,order,dx,m) 
-            for i = 2:n
-                output *= calc_coeff_mat(input.args[i],iv,grade,order,dx,m) 
-            end
+            output = prod(i -> calc_coeff_mat(input.args[i],iv,grade,order,dx,m),
+                          eachindex(input.args))
             return output
         end
     end
@@ -63,7 +60,7 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
     domain = pdesys.domain[2].domain
     @assert domain isa IntervalDomain
     len = domain.upper-domain.lower
-    dx = discretization.dxs[1]
+    dx = discretization.dxs
     interior = domain.lower+dx:dx:domain.upper-dx
     X = domain.lower:dx:domain.upper
     m = size(X,1)-2

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -71,11 +71,11 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
     (u_t0,u_x0,u_x1) = extract_bc(pdesys.bcs,tdomain,domain)
     Q = DirichletBC(u_x0,u_x1)
     function f(du,u,p,t)
-        mul!(du,L,Array(Q*u))
+        mul!(du,L,Q*u)
+
     end
     t = 0.0
     u0 = eval_expr(u_t0,interior,t)
     PDEProblem(ODEProblem(f,u0,(tdomain.lower,tdomain.upper),nothing),Q,X)
 end
-
 

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -132,7 +132,11 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
     xx = []
     for i = 1:no_iv-1
         domain = vcat(domain,pdesys.domain[i+1].domain)
-        dx = vcat(dx,discretization.dxs)
+        if discretization.dxs isa Float64
+            dx = vcat(dx,discretization.dxs)
+        else
+            dx = vcat(dx,discretization.dxs[1])
+        end
         X = vcat(X,domain[i].lower:dx[i]:domain[i].upper)
         xx = vcat(xx,size(X,1)-2)
     end
@@ -211,10 +215,11 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
             for i = 1:xx[1]
                 du[i,j] = Base.invokelatest(disc,Qu,t,i+1)
             end
-            j = j+1
+            j = j+1 
         end
     end
 
     # Return problem ###########################################################
     return PDEProblem(ODEProblem(f,u0,(tdomain.lower,tdomain.upper),nothing),Q,X)
 end
+

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -34,11 +34,11 @@ end
 # Calculate coefficient matrix of the finite-difference scheme
 function calc_coeff_mat(input,iv,grade,order,dx,m)
     if input isa ModelingToolkit.Constant
-            return input.value
+        return input.value
     elseif input isa Operation
         if input.op isa Variable
             if grade == 1
-                L = UpwindDifference(grade,order,dx,m,-1)
+                L = UpwindDifference(grade,order,dx,m,1)
             else
                 L = CenteredDifference(grade,order,dx,m)
             end
@@ -46,6 +46,8 @@ function calc_coeff_mat(input,iv,grade,order,dx,m)
         elseif input.op isa Differential
             grade += 1
             return calc_coeff_mat(input.args[1],input.op.x,grade,order,dx,m)
+        elseif input.op isa typeof(-)
+            return -1 * calc_coeff_mat(input.args[1],iv,grade,order,dx,m)
         elseif input.op isa typeof(*)
             output = prod(i -> calc_coeff_mat(input.args[i],iv,grade,order,dx,m),
                           eachindex(input.args))

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -72,7 +72,6 @@ function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDiffer
     Q = DirichletBC(u_x0,u_x1)
     function f(du,u,p,t)
         mul!(du,L,Q*u)
-
     end
     t = 0.0
     u0 = eval_expr(u_t0,interior,t)

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -1,22 +1,81 @@
+# Method of lines discretization scheme
 struct MOLFiniteDifference{T} <: DiffEqBase.AbstractDiscretization
   dxs::T
   order::Int
 end
 MOLFiniteDifference(args...;order=2) = MOLFiniteDifference(args,order)
 
-function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDifference)
-  tdomain = pdesys.domain[1].domain
-  domain = pdesys.domain[2].domain
-  @assert domain isa IntervalDomain
-  len = domain.upper - domain.lower
-  dx = discretization.dxs[1]
-  interior = domain.lower+dx:dx:domain.upper-dx
-  X = domain.lower:dx:domain.upper
-  L = CenteredDifference(2,2,dx,Int(len/dx)-2)
-  Q = DirichletBC(0.0,0.0)
-  function f(du,u,p,t)
-    mul!(du,L,Array(Q*u))
-  end
-  u0 = @. - interior * (interior - 1) * sin(interior)
-  PDEProblem(ODEProblem(f,u0,(tdomain.lower,tdomain.upper),nothing),Q,X)
+# Evaluate expression
+function eval_expr(expr,x,y)
+   f = eval(:((x,y) -> $expr))
+   return @eval $f.($x,$y)
 end
+
+# Obtain boundary conditions from an array
+function extract_bc(bcs,tdomain,domain)
+    u_t0 = 0.0
+    u_x0 = 0.0
+    u_x1 = 0.0
+    n = size(bcs)[1]
+    for i = 1:n
+        if isa(bcs[i].lhs.op,Variable)
+            if isequal(bcs[i].lhs.args[1],tdomain.lower) # u(t=0,x)
+                u_t0 = Expr(bcs[i].rhs)
+            elseif isequal(bcs[i].lhs.args[2],domain.lower) # u(t,x=x_init)
+                u_x0 = bcs[i].rhs.value
+            elseif isequal(bcs[i].lhs.args[2],domain.upper) # u(t,x=x_final)
+                u_x1 = bcs[i].rhs.value
+            end
+        end
+    end
+    return (u_t0,u_x0,u_x1)
+end
+
+# Calculate coefficient matrix of the finite-difference scheme
+function calc_coeff_mat(input,iv,grade,order,dx,m)
+    if isa(input,ModelingToolkit.Constant)
+            return input.value
+    elseif isa(input,Operation)
+        if isa(input.op,Variable)
+            if grade == 1
+                L = UpwindDifference(grade,order,dx,m,-1)
+            else
+                L = CenteredDifference(grade,order,dx,m)
+            end
+            return L
+        elseif isa(input.op,Differential)
+            grade += 1
+            calc_coeff_mat(input.args[1],input.op.x,grade,order,dx,m)
+        elseif isa(input.op,typeof(*))
+            n = size(input.args)[1]
+            output = calc_coeff_mat(input.args[1],iv,grade,order,dx,m) 
+            for i = 2:n
+                output *= calc_coeff_mat(input.args[i],iv,grade,order,dx,m) 
+            end
+            return output
+        end
+    end
+end
+
+# Convert a PDE problem into an ODE problem
+function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDifference)
+    tdomain = pdesys.domain[1].domain
+    domain = pdesys.domain[2].domain
+    @assert domain isa IntervalDomain
+    len = domain.upper-domain.lower
+    dx = discretization.dxs[1]
+    interior = domain.lower+dx:dx:domain.upper-dx
+    X = domain.lower:dx:domain.upper
+    m = size(X)[1]-2
+    L = calc_coeff_mat(pdesys.eq.rhs,pdesys.indvars[2],0,discretization.order,dx,m)
+    (u_t0,u_x0,u_x1) = extract_bc(pdesys.bcs,tdomain,domain)
+    Q = DirichletBC(u_x0,u_x1)
+    function f(du,u,p,t)
+        mul!(du,L,Array(Q*u))
+    end
+    t = 0.0
+    u0 = eval_expr(u_t0,interior,t)
+    PDEProblem(ODEProblem(f,u0,(tdomain.lower,tdomain.upper),nothing),Q,X)
+end
+
+

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -1,3 +1,5 @@
+using Reduce
+
 # Method of lines discretization scheme
 struct MOLFiniteDifference{T} <: DiffEqBase.AbstractDiscretization
   dxs::T
@@ -6,13 +8,14 @@ end
 MOLFiniteDifference(args...;order=2) = MOLFiniteDifference(args,order)
 
 # Evaluate expression
+# TODO: replace this eval with proper substitution
 function eval_expr(expr,x,y)
    f = eval(:((x,y) -> $expr))
    return @eval $f.($x,$y)
 end
 
-# Obtain boundary conditions from an array
-function extract_bc(bcs,tdomain,domain)
+# Get boundary conditions from an array
+function get_bcs(bcs,tdomain,domain)
     u_t0 = 0.0
     u_x0 = 0.0
     u_x1 = 0.0
@@ -32,47 +35,112 @@ function extract_bc(bcs,tdomain,domain)
 end
 
 # Calculate coefficient matrix of the finite-difference scheme
-function calc_coeff_mat(input,iv,grade,order,dx,m)
+# Note: 'non-derived' dependent variables are inserted into the diff. equations
+#       E.g. Dx(u(t,x))=v(t,x)*Dx(u(t,x)), v(t,x)=t*x
+#            =>  Dx(u(t,x))=t*x*Dx(u(t,x))
+function calc_coeff_mat(input,iv,grade,order,dx,m,nonderiv_depvars)
     if input isa ModelingToolkit.Constant
-        return input.value
+        return :($input.value)
     elseif input isa Operation
         if input.op isa Variable
-            if grade == 1
-                L = UpwindDifference(grade,order,dx,m,1)
+            if haskey(nonderiv_depvars,input.op)
+                # TODO: fix this substitution, it does not work for :x=>:($j*$dx)
+                # TODO: use D(t,x) = t*x in tests
+                L = [ j==k ? Algebra.sub(:x=>:($j),nonderiv_depvars[input.op]) : :(0) for j=1:m, k=1:m ]
+            elseif grade == 1
+                L = :($(UpwindDifference(grade,order,dx,m,1)))
             else
-                L = CenteredDifference(grade,order,dx,m)
+                L = :($(CenteredDifference(grade,order,dx,m)))
             end
             return L
         elseif input.op isa Differential
             grade += 1
-            return calc_coeff_mat(input.args[1],input.op.x,grade,order,dx,m)
+            return calc_coeff_mat(input.args[1],input.op.x,grade,order,dx,m,nonderiv_depvars)
         elseif input.op isa typeof(-)
-            return -1 * calc_coeff_mat(input.args[1],iv,grade,order,dx,m)
+            L = calc_coeff_mat(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
+            return Expr(:call, :*, :(-1), L)
         elseif input.op isa typeof(*)
-            output = prod(i -> calc_coeff_mat(input.args[i],iv,grade,order,dx,m),
-                          eachindex(input.args))
-            return output
+            # TODO: probably the code below can be shortened
+            expr1 = calc_coeff_mat(input.args[1],iv,grade,order,dx,m,nonderiv_depvars)
+            expr2 = calc_coeff_mat(input.args[2],iv,grade,order,dx,m,nonderiv_depvars)
+            expr1 = Expr(:call, :*, expr1, expr2)
+            for i = 3:size(input.args,1)
+                expr2 = calc_coeff_mat(input.args[i],iv,grade,order,dx,m,nonderiv_depvars)
+                expr1 = Expr(:call, :*, expr1, expr2)
+            end
+            return expr1
         end
     end
 end
 
 # Convert a PDE problem into an ODE problem
 function DiffEqBase.discretize(pdesys::PDESystem,discretization::MOLFiniteDifference)
+
+    ### Get spatial and temporal domains #######################################
     tdomain = pdesys.domain[1].domain
     domain = pdesys.domain[2].domain
+    @assert tdomain isa IntervalDomain
     @assert domain isa IntervalDomain
-    len = domain.upper-domain.lower
     dx = discretization.dxs
     interior = domain.lower+dx:dx:domain.upper-dx
     X = domain.lower:dx:domain.upper
+    order = discretization.order
     m = size(X,1)-2
-    L = calc_coeff_mat(pdesys.eq.rhs,pdesys.indvars[2],0,discretization.order,dx,m)
-    (u_t0,u_x0,u_x1) = extract_bc(pdesys.bcs,tdomain,domain)
-    Q = DirichletBC(u_x0,u_x1)
-    function f(du,u,p,t)
-        mul!(du,L,Q*u)
+
+    ### Calculate coefficient matrices #########################################
+    # Each coeff. matrix (L_expr[x]) is an expression which is then evaluated 
+    # in the ODE function (f)
+
+    # TODO: improve the code below using index arrays instead of Dicts?
+    nonderiv_depvars = Dict()
+    deriv_depvars = Dict()
+    L_expr = Dict()
+    # if there is only one equation
+    if pdesys.eq isa Equation
+        x = pdesys.eq.lhs.op
+        L_expr[x] = calc_coeff_mat(pdesys.eq.rhs,pdesys.indvars[2],0,
+                                   order,dx,m,Dict())
+    # if there are many equations (pdesys.eq isa Array)
+    else
+        # Store 'non-derived' dependent variables (e.g. v(t,x)=t*x)
+        # and 'derived' dependent variables (e.g. Dxx(u(t,x)))
+        n_eqs = size(pdesys.eq,1)
+        for i = 1:n_eqs
+            x = pdesys.eq[i].lhs.op
+            if x isa Variable
+                nonderiv_depvars[x] = pdesys.eq[i].rhs
+            else #x isa Differential
+                deriv_depvars[x] = pdesys.eq[i].rhs
+            end
+        end
+
+        # Calc. coeff. matrix for each differential equation
+        for (x,rhs) in deriv_depvars
+            L_expr[x] = calc_coeff_mat(rhs,pdesys.indvars[2],0,order,
+                                       dx,m,nonderiv_depvars)
+        end
     end
+
+    ### Get boundary conditions ################################################
+    # TODO: generalize to N equations
+    # TODO: eval issue
+    (u_t0,u_x0,u_x1) = get_bcs(pdesys.bcs,tdomain,domain)
     t = 0.0
     u0 = eval_expr(u_t0,interior,t)
-    PDEProblem(ODEProblem(f,u0,(tdomain.lower,tdomain.upper),nothing),Q,X)
+    Q = DirichletBC(u_x0,u_x1)
+
+    ### Define the discretized PDE as an ODE function ##########################
+    function f(du,u,p,t)
+        for L in values(L_expr)
+            # TODO: the eval will probably change when the substitution in 
+            # calc_coeff_mat is fixed
+            LL = eval(L)
+            mul!(du,LL,Q*u)
+        end
+    end
+
+    # Return problem ###########################################################
+    return PDEProblem(ODEProblem(f,u0,(tdomain.lower,tdomain.upper),nothing),Q,X)
 end
+
+

--- a/test/MOL_0D_Logistic.jl
+++ b/test/MOL_0D_Logistic.jl
@@ -1,0 +1,53 @@
+# Logistic Equation (test incomplete)
+
+# Packages and inclusions
+using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
+
+# Tests
+@testset "Test 00: Dt(u(t)) ~ u(t)*(1.0-u(t))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ 0.0*Dx(u(t,x))+u(t,x)*(1.0-u(t,x))
+    bcs = [ u(0,x) ~ 0.5+x*0.0,
+            u(t,0) ~ 0.5,
+            u(t,1) ~ 0.5]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,5.0),
+               x ∈ IntervalDomain(0.0,1.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 0.1
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    
+    sol = solve(prob,Euler(),dt=0.01,saveat=0.1)
+
+    # Plot and save results
+    using Plots
+    time = domains[1].domain.lower:0.1:domains[1].domain.upper
+
+    plot(time,sol[5,1,:])
+    savefig("MOL_0D_Logistic.png")
+
+    # Test
+    # x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    # u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+0.6))^2/(2.0*0.2^2))
+    # t_f = size(sol,3)
+    # @test sol[t_f] ≈ u atol = 0.1;
+
+end

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -31,7 +31,7 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     discretization = MOLFiniteDifference(dx,order)
 
     # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization) 
+    prob = discretize(pdesys,discretization)
 
     # Solve ODE problem
     using OrdinaryDiffEq
@@ -55,7 +55,58 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
 end
 
-@testset "Test 01: Dt(u(t,x)) ~ -v*Dx(u(t,x))" begin
+@testset "Test 01: Dt(u(t,x)) ~ -Dx(u(t,x)) + 0.01" begin
+
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ -Dx(u(t,x)) + 0.01
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+    # Plot and save results
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation*sol[1]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[2]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[3]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[4]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[5]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[6]))
+    # savefig("MOL_1D_Linear_Convection_Test01.png")
+
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ u atol = 0.1;
+
+end
+
+@testset "Test 02: Dt(u(t,x)) ~ -v*Dx(u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x v
     @variables u(..)
@@ -83,7 +134,7 @@ end
     discretization = MOLFiniteDifference(dx,order)
 
     # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization) 
+    prob = discretize(pdesys,discretization)
 
     # Solve ODE problem
     using OrdinaryDiffEq
@@ -97,7 +148,7 @@ end
 #    plot!(prob.space,Array(prob.extrapolation*sol[4]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[5]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test01.png")
+#    savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -107,7 +158,7 @@ end
 end
 
 
-@testset "Test 02: Dt(u(t,x)) ~ -Dx(v*u(t,x))" begin
+@testset "Test 03: Dt(u(t,x)) ~ -Dx(v*u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x v
     @variables u(..)
@@ -135,7 +186,7 @@ end
     discretization = MOLFiniteDifference(dx,order)
 
     # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization) 
+    prob = discretize(pdesys,discretization)
 
     # Solve ODE problem
     using OrdinaryDiffEq
@@ -149,7 +200,7 @@ end
 #    plot!(prob.space,Array(prob.extrapolation*sol[4]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[5]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test02.png")
+#    savefig("MOL_1D_Linear_Convection_Test03.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -159,7 +210,7 @@ end
 end
 
 
-@testset "Test 03: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)) with v(t,x)=1" begin
+@testset "Test 04: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)) with v(t,x)=1" begin
     # Parameters, variables, and derivatives
     @parameters t x
     @variables v(..) u(..)
@@ -167,7 +218,7 @@ end
     @derivatives Dx'~x
 
     # 1D PDE and boundary conditions
-    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)), 
+    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)),
             v(t,x) ~ 1.0 ]
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
@@ -186,7 +237,7 @@ end
     discretization = MOLFiniteDifference(dx,order)
 
     # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization) 
+    prob = discretize(pdesys,discretization)
 
     # Solve ODE problem
     using OrdinaryDiffEq
@@ -200,7 +251,7 @@ end
 #    plot!(prob.space,Array(prob.extrapolation*sol[4]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[5]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test03.png")
+#    savefig("MOL_1D_Linear_Convection_Test04.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -210,7 +261,7 @@ end
     @test sol[t_f] ≈ u atol = 0.1;
 end
 
-@testset "Test 04: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x))" begin
+@testset "Test 05: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x
     @variables v(..) u(..)
@@ -218,7 +269,7 @@ end
     @derivatives Dx'~x
 
     # 1D PDE and boundary conditions
-    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)), 
+    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)),
             v(t,x) ~ 0.999 + 0.001 * t * x ]
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
@@ -237,7 +288,7 @@ end
     discretization = MOLFiniteDifference(dx,order)
 
     # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization) 
+    prob = discretize(pdesys,discretization)
 
     # Solve ODE problem
     using OrdinaryDiffEq
@@ -251,58 +302,7 @@ end
 #    plot!(prob.space,Array(prob.extrapolation*sol[4]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[5]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test04.png")
-
-    # Test
-    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
-    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.0*0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
-
-    @test sol[t_f] ≈ u atol = 0.1;
-end
-
-@testset "Test 05: Dt(u(t,x)) ~ -v(t,x)*Dx(u(t,x))" begin
-    # Parameters, variables, and derivatives
-    @parameters t x
-    @variables v(..) u(..)
-    @derivatives Dt'~t
-    @derivatives Dx'~x
-
-    # 1D PDE and boundary conditions
-    eq  = [ Dt(u(t,x)) ~ -v(t,x)*Dx(u(t,x)), 
-            v(t,x) ~ 0.999 + 0.001 * t * x ]
-    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
-           u(t,0) ~ 0.0,
-           u(t,2) ~ 0.0]
-
-    # Space and time domains
-    domains = [t ∈ IntervalDomain(0.0,0.6),
-               x ∈ IntervalDomain(0.0,2.0)]
-
-    # PDE system
-    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
-
-    # Method of lines discretization
-    dx = 2/80
-    order = 1
-    discretization = MOLFiniteDifference(dx,order)
-
-    # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization) 
-
-    # Solve ODE problem
-    using OrdinaryDiffEq
-    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
-
-#    #Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test04.png")
+#    savefig("MOL_1D_Linear_Convection_Test05.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -39,19 +39,19 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
     # Plot and save results
     using Plots
-    plot(prob.space,Array(prob.extrapolation*sol[1]))
-    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
     savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ u atol = 0.1;
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ u atol = 0.1;
 
 end
 
@@ -89,20 +89,20 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation*sol[1]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[2]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[3]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[4]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[5]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[6]))
-    # savefig("MOL_1D_Linear_Convection_Test01.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ u atol = 0.1;
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ u atol = 0.1;
 
 end
 
@@ -140,21 +140,21 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-#    # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test02.png")
+    # Plot and save results
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+v*0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ u atol = 0.1;
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ u atol = 0.1;
 end
 
 
@@ -193,20 +193,20 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test03.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test03.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+v*0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ u atol = 0.1;
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ u atol = 0.1;
 end
 
 
@@ -244,21 +244,21 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test04.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test04.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.0*0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
+    t_f = size(sol,3)
 
-    @test sol[t_f] ≈ u atol = 0.1;
+    @test sol[:,1,t_f] ≈ u atol = 0.1;
 end
 
 @testset "Test 05: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x))" begin
@@ -294,20 +294,20 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-#    #Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test05.png")
+   #Plot and save results
+   using Plots
+   plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+   savefig("MOL_1D_Linear_Convection_Test05.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.0*0.6))^2/(2.0*0.2^2))
-    t_f = size(sol)[2]
+    t_f = size(sol,3)
 
-    @test sol[t_f] ≈ u atol = 0.1;
+    @test sol[:,1,t_f] ≈ u atol = 0.1;
 end

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -39,12 +39,12 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
     # Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,6]))
     # savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
@@ -92,12 +92,12 @@ end
 
     # Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,6]))
     # savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
@@ -144,12 +144,12 @@ end
 
     # Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,6]))
     # savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
@@ -198,12 +198,12 @@ end
 
     #Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,6]))
     # savefig("MOL_1D_Linear_Convection_Test03.png")
 
     # Test
@@ -250,14 +250,14 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-    #Plot and save results
+    # Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,6]))
     # savefig("MOL_1D_Linear_Convection_Test04.png")
 
     # Test

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -38,14 +38,14 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test00.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -89,14 +89,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test01.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -141,14 +141,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test02.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -193,14 +193,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test03.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test03.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -244,14 +244,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test04.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test04.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -294,15 +294,15 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-   #Plot and save results
-   using Plots
-   plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-   plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-   savefig("MOL_1D_Linear_Convection_Test05.png")
+    #Plot and save results
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test05.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -4,7 +4,7 @@
 using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
 # Tests
-@testset "Test 00: Dt(u(t,x)) ~ Dx(u(t,x))" begin
+@testset "Test 00: Dt(u(t,x)) ~ -Dx(u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x
     @variables u(..)
@@ -12,7 +12,7 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     @derivatives Dx'~x
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ Dx(u(t,x))
+    eq  = Dt(u(t,x)) ~ -Dx(u(t,x))
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
            u(t,2) ~ 0.0]
@@ -37,14 +37,14 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test00.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation*sol[1]))
+    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+    savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -54,7 +54,7 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
 end
 
-@testset "Test 01: Dt(u(t,x)) ~ v*Dx(u(t,x))" begin
+@testset "Test 01: Dt(u(t,x)) ~ -v*Dx(u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x v
     @variables u(..)
@@ -64,7 +64,7 @@ end
     v = 1.1
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ v*Dx(u(t,x))
+    eq  = Dt(u(t,x)) ~ -v*Dx(u(t,x))
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
            u(t,2) ~ 0.0]
@@ -89,14 +89,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test01.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation*sol[1]))
+    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+    savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -105,7 +105,7 @@ end
     @test sol[t_f] ≈ u atol = 0.1;
 end
 
-@testset "Test 02: Dt(u(t,x)) ~ Dx(v*u(t,x))" begin
+@testset "Test 02: Dt(u(t,x)) ~ -Dx(v*u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x v
     @variables u(..)
@@ -115,7 +115,7 @@ end
     v = 1.1
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ Dx(v*u(t,x))
+    eq  = Dt(u(t,x)) ~ -Dx(v*u(t,x))
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
            u(t,2) ~ 0.0]
@@ -139,15 +139,15 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-    # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test02.png")
+    #Plot and save results
+    using Plots
+    plot(prob.space,Array(prob.extrapolation*sol[1]))
+    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+    savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -37,15 +37,15 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-#    # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#    savefig("MOL_1D_Linear_Convection_Test00.png")
+    # Plot and save results
+    using Plots
+    plot(prob.space,Array(prob.extrapolation*sol[1]))
+    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+    savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -219,8 +219,58 @@ end
 
     # 1D PDE and boundary conditions
     eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)), 
-            v(t,x) ~ 1. + 0.0 * t * x ]
-#            v(t,x) ~ 1. ]
+            v(t,x) ~ 0.999 + 0.001 * t * x ]
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization) 
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+#    #Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test04.png")
+
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.0*0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+
+    @test sol[t_f] ≈ u atol = 0.1;
+end
+
+@testset "Test 05: Dt(u(t,x)) ~ -v(t,x)*Dx(u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables v(..) u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    # 1D PDE and boundary conditions
+    eq  = [ Dt(u(t,x)) ~ -v(t,x)*Dx(u(t,x)), 
+            v(t,x) ~ 0.999 + 0.001 * t * x ]
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
            u(t,2) ~ 0.0]

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -36,15 +36,17 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-    # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation*sol[1]))
-    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-    savefig("MOL_1D_Linear_Convection_Test00.png")
+    println("fin")
+
+#    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -88,15 +90,15 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-    # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation*sol[1]))
-    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-    savefig("MOL_1D_Linear_Convection_Test01.png")
+#    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -140,14 +142,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation*sol[1]))
-    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-    plot!(prob.space,Array(prob.extrapolation*sol[5]))
-    plot!(prob.space,Array(prob.extrapolation*sol[6]))
-    savefig("MOL_1D_Linear_Convection_Test02.png")
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -1,0 +1,45 @@
+# 1D linear convection problem
+
+# Packages and inclusions
+using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra
+
+# Parameters, variables, and derivatives
+@parameters t x
+@variables u(..)
+@derivatives Dt'~t
+@derivatives Dx'~x
+
+# 1D PDE and boundary conditions
+eq  = Dt(u(t,x)) ~ 1.1 * Dx(u(t,x))
+bcs = [u(0,x) ~ (1.0/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
+       u(t,0) ~ 0.0,
+       u(t,2) ~ 0.0]
+
+# Space and time domains
+domains = [t ∈ IntervalDomain(0.0,0.6),
+           x ∈ IntervalDomain(0.0,2.0)]
+
+# PDE system
+pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+# Method of lines discretization
+dx = 2/40
+order = 1
+discretization = MOLFiniteDifference(dx,order)
+
+# Convert the PDE problem into an ODE problem
+prob = discretize(pdesys,discretization) 
+
+# Solve ODE problem
+using OrdinaryDiffEq
+sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+# Plot and save results
+using Plots
+plot(prob.space,Array(prob.extrapolation*sol[1]))
+plot!(prob.space,Array(prob.extrapolation*sol[2]))
+plot!(prob.space,Array(prob.extrapolation*sol[3]))
+plot!(prob.space,Array(prob.extrapolation*sol[4]))
+plot!(prob.space,Array(prob.extrapolation*sol[5]))
+plot!(prob.space,Array(prob.extrapolation*sol[6]))
+savefig("MOL_1D_Linear_Convection.png")

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -4,6 +4,7 @@
 using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
 # Tests
+
 @testset "Test 00: Dt(u(t,x)) ~ -Dx(u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x
@@ -36,8 +37,6 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-    println("fin")
-
 #    # Plot and save results
 #    using Plots
 #    plot(prob.space,Array(prob.extrapolation*sol[1]))
@@ -63,7 +62,7 @@ end
     @derivatives Dt'~t
     @derivatives Dx'~x
 
-    v = 1.1
+    v = 1.0
 
     # 1D PDE and boundary conditions
     eq  = Dt(u(t,x)) ~ -v*Dx(u(t,x))
@@ -106,6 +105,7 @@ end
     t_f = size(sol)[2]
     @test sol[t_f] ≈ u atol = 0.1;
 end
+
 
 @testset "Test 02: Dt(u(t,x)) ~ -Dx(v*u(t,x))" begin
     # Parameters, variables, and derivatives
@@ -155,5 +155,109 @@ end
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+v*0.6))^2/(2.0*0.2^2))
     t_f = size(sol)[2]
+    @test sol[t_f] ≈ u atol = 0.1;
+end
+
+
+@testset "Test 03: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)) with v(t,x)=1" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables v(..) u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    # 1D PDE and boundary conditions
+    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)), 
+            v(t,x) ~ 1.0 ]
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization) 
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+    #Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test03.png")
+
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.0*0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+
+    @test sol[t_f] ≈ u atol = 0.1;
+end
+
+@testset "Test 04: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables v(..) u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    # 1D PDE and boundary conditions
+    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)), 
+            v(t,x) ~ 1. + 0.0 * t * x ]
+#            v(t,x) ~ 1. ]
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization) 
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+#    #Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test04.png")
+
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.0*0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+
     @test sol[t_f] ≈ u atol = 0.1;
 end

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -1,7 +1,7 @@
 # 1D linear convection problem
 
 # Packages and inclusions
-using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra
+using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
 # Parameters, variables, and derivatives
 @parameters t x
@@ -11,7 +11,7 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra
 
 # 1D PDE and boundary conditions
 eq  = Dt(u(t,x)) ~ 1.1 * Dx(u(t,x))
-bcs = [u(0,x) ~ (1.0/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
+bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
        u(t,0) ~ 0.0,
        u(t,2) ~ 0.0]
 
@@ -23,7 +23,7 @@ domains = [t ∈ IntervalDomain(0.0,0.6),
 pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
 
 # Method of lines discretization
-dx = 2/40
+dx = 2/80
 order = 1
 discretization = MOLFiniteDifference(dx,order)
 
@@ -34,12 +34,18 @@ prob = discretize(pdesys,discretization)
 using OrdinaryDiffEq
 sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
+# Test
+x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.1*0.6))^2/(2.0*0.2^2))
+t_f = size(sol)[2]
+@test sol[t_f] ≈ u atol = 0.1;
+
 # Plot and save results
-using Plots
-plot(prob.space,Array(prob.extrapolation*sol[1]))
-plot!(prob.space,Array(prob.extrapolation*sol[2]))
-plot!(prob.space,Array(prob.extrapolation*sol[3]))
-plot!(prob.space,Array(prob.extrapolation*sol[4]))
-plot!(prob.space,Array(prob.extrapolation*sol[5]))
-plot!(prob.space,Array(prob.extrapolation*sol[6]))
-savefig("MOL_1D_Linear_Convection.png")
+#using Plots
+#plot(prob.space,Array(prob.extrapolation*sol[1]))
+#plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#savefig("MOL_1D_Linear_Convection.png")

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -38,14 +38,14 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test00.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -91,14 +91,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test01.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -143,14 +143,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test02.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -197,14 +197,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test03.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test03.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -251,14 +251,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    savefig("MOL_1D_Linear_Convection_Test04.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    # savefig("MOL_1D_Linear_Convection_Test04.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -38,20 +38,22 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    # savefig("MOL_1D_Linear_Convection_Test00.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test00.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
     u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+0.6))^2/(2.0*0.2^2))
     t_f = size(sol,3)
+
     @test sol[:,1,t_f] ≈ u atol = 0.1;
+    
 
 end
 
@@ -89,14 +91,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    # savefig("MOL_1D_Linear_Convection_Test01.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test01.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -141,14 +143,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    # savefig("MOL_1D_Linear_Convection_Test02.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test02.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -157,60 +159,7 @@ end
     @test sol[:,1,t_f] ≈ u atol = 0.1;
 end
 
-
-@testset "Test 03: Dt(u(t,x)) ~ -Dx(v*u(t,x))" begin
-    # Parameters, variables, and derivatives
-    @parameters t x v
-    @variables u(..)
-    @derivatives Dt'~t
-    @derivatives Dx'~x
-
-    v = 1.1
-
-    # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ -Dx(v*u(t,x))
-    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
-           u(t,0) ~ 0.0,
-           u(t,2) ~ 0.0]
-
-    # Space and time domains
-    domains = [t ∈ IntervalDomain(0.0,0.6),
-               x ∈ IntervalDomain(0.0,2.0)]
-
-    # PDE system
-    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
-
-    # Method of lines discretization
-    dx = 2/80
-    order = 1
-    discretization = MOLFiniteDifference(dx,order)
-
-    # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization)
-
-    # Solve ODE problem
-    using OrdinaryDiffEq
-    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
-
-    #Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    # savefig("MOL_1D_Linear_Convection_Test03.png")
-
-    # Test
-    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
-    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+v*0.6))^2/(2.0*0.2^2))
-    t_f = size(sol,3)
-    @test sol[:,1,t_f] ≈ u atol = 0.1;
-end
-
-
-@testset "Test 04: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)) with v(t,x)=1" begin
+@testset "Test 03: Dt(u(t,x)) ~ -Dx(v(t,x))*u(t,x)-v(t,x)*Dx(u(t,x)) with v(t,x)=1" begin
     # Parameters, variables, and derivatives
     @parameters t x
     @variables v(..) u(..)
@@ -218,18 +167,22 @@ end
     @derivatives Dx'~x
 
     # 1D PDE and boundary conditions
-    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)),
+    eq  = [ Dt(u(t,x)) ~ -(Dx(v(t,x))*u(t,x)+v(t,x)*Dx(u(t,x))),
             v(t,x) ~ 1.0 ]
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
-           u(t,2) ~ 0.0]
+           u(t,2) ~ 0.0,
+           v(0,x) ~ 1.0,
+           v(t,0) ~ 1.0,
+           v(t,2) ~ 1.0
+           ]
 
     # Space and time domains
     domains = [t ∈ IntervalDomain(0.0,0.6),
                x ∈ IntervalDomain(0.0,2.0)]
 
     # PDE system
-    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u,v])
 
     # Method of lines discretization
     dx = 2/80
@@ -244,14 +197,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    # savefig("MOL_1D_Linear_Convection_Test04.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test03.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
@@ -261,7 +214,7 @@ end
     @test sol[:,1,t_f] ≈ u atol = 0.1;
 end
 
-@testset "Test 05: Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x))" begin
+@testset "Test 04: Dt(u(t,x)) ~ -Dx(v(t,x))*u(t,x)-v(t,x)*Dx(u(t,x)) with v(t,x)=0.999 + 0.001 * t * x " begin
     # Parameters, variables, and derivatives
     @parameters t x
     @variables v(..) u(..)
@@ -269,18 +222,21 @@ end
     @derivatives Dx'~x
 
     # 1D PDE and boundary conditions
-    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x)*u(t,x)),
+    eq  = [ Dt(u(t,x)) ~ -Dx(v(t,x))*u(t,x)-v(t,x)*Dx(u(t,x)),
             v(t,x) ~ 0.999 + 0.001 * t * x ]
     bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
            u(t,0) ~ 0.0,
-           u(t,2) ~ 0.0]
+           u(t,2) ~ 0.0,
+           v(0,x) ~ 0.999,
+           v(t,0) ~ 0.999,
+           v(t,2) ~ 0.999 + 0.001 * t * 2.0]
 
     # Space and time domains
     domains = [t ∈ IntervalDomain(0.0,0.6),
                x ∈ IntervalDomain(0.0,2.0)]
 
     # PDE system
-    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u,v])
 
     # Method of lines discretization
     dx = 2/80
@@ -295,14 +251,14 @@ end
     sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
     #Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
-    # savefig("MOL_1D_Linear_Convection_Test05.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,5]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,6]))
+    savefig("MOL_1D_Linear_Convection_Test04.png")
 
     # Test
     x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx

--- a/test/MOL_1D_Linear_Convection.jl
+++ b/test/MOL_1D_Linear_Convection.jl
@@ -3,49 +3,155 @@
 # Packages and inclusions
 using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
-# Parameters, variables, and derivatives
-@parameters t x
-@variables u(..)
-@derivatives Dt'~t
-@derivatives Dx'~x
+# Tests
+@testset "Test 00: Dt(u(t,x)) ~ Dx(u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
 
-# 1D PDE and boundary conditions
-eq  = Dt(u(t,x)) ~ 1.1 * Dx(u(t,x))
-bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
-       u(t,0) ~ 0.0,
-       u(t,2) ~ 0.0]
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ Dx(u(t,x))
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x  -0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
 
-# Space and time domains
-domains = [t ∈ IntervalDomain(0.0,0.6),
-           x ∈ IntervalDomain(0.0,2.0)]
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
 
-# PDE system
-pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
 
-# Method of lines discretization
-dx = 2/80
-order = 1
-discretization = MOLFiniteDifference(dx,order)
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
 
-# Convert the PDE problem into an ODE problem
-prob = discretize(pdesys,discretization) 
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization) 
 
-# Solve ODE problem
-using OrdinaryDiffEq
-sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
 
-# Test
-x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
-u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+1.1*0.6))^2/(2.0*0.2^2))
-t_f = size(sol)[2]
-@test sol[t_f] ≈ u atol = 0.1;
+    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test00.png")
 
-# Plot and save results
-#using Plots
-#plot(prob.space,Array(prob.extrapolation*sol[1]))
-#plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#plot!(prob.space,Array(prob.extrapolation*sol[5]))
-#plot!(prob.space,Array(prob.extrapolation*sol[6]))
-#savefig("MOL_1D_Linear_Convection.png")
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ u atol = 0.1;
+
+end
+
+@testset "Test 01: Dt(u(t,x)) ~ v*Dx(u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x v
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    v = 1.1
+
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ v*Dx(u(t,x))
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization) 
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test01.png")
+
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+v*0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ u atol = 0.1;
+end
+
+@testset "Test 02: Dt(u(t,x)) ~ Dx(v*u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x v
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dx'~x
+
+    v = 1.1
+
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ Dx(v*u(t,x))
+    bcs = [u(0,x) ~ (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x-0.75)^2/(2.0*0.2^2)),
+           u(t,0) ~ 0.0,
+           u(t,2) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,0.6),
+               x ∈ IntervalDomain(0.0,2.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+    # Method of lines discretization
+    dx = 2/80
+    order = 1
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization) 
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Euler(),dt=.025,saveat=0.1)
+
+    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[5]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[6]))
+#    savefig("MOL_1D_Linear_Convection_Test02.png")
+
+    # Test
+    x_interval = domains[2].domain.lower+dx:dx:domains[2].domain.upper-dx
+    u = @. (0.5/(0.2*sqrt(2.0*3.1415)))*exp(-(x_interval-(0.75+v*0.6))^2/(2.0*0.2^2))
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ u atol = 0.1;
+end

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -1,5 +1,7 @@
 # 1D diffusion problem
 
+# TODO: Add more complex tests.
+
 # Packages and inclusions
 using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
@@ -151,12 +153,12 @@ end
     @parameters t x
     @variables u(..) D(..)
     @derivatives Dt'~t
-    @derivatives Dxx''~x
+    @derivatives Dx'~x
 
     # 1D PDE and boundary conditions
     # TODO: use D(t,x) ~ t*x
-    eq  = [ Dt(u(t,x)) ~ Dxx(D(t,x)*u(t,x)),
-            D(t,x) ~ x ]
+    eq  = [ Dt(u(t,x)) ~ Dx(D(t,x)*Dx(u(t,x))),
+            D(t,x) ~ 1/(1+exp(-x*t)) ]
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]
@@ -191,7 +193,7 @@ end
     # Test
     n = size(sol)[1]
     t_f = size(sol)[2]
-    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+    @test sol[t_f] ≈ zeros(n) atol = 0.01;
 end
 
 

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -38,14 +38,12 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
 
-    #sol = solve(prob,,IDA(),saveat=0.1)
-
     #Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
     # savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
     # Test
@@ -91,10 +89,10 @@ end
 
     # Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
     # savefig("MOL_1D_Linear_Diffusion_Test01.png")
 
     # Test
@@ -144,10 +142,10 @@ end
     
     # Plot and save results
     # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # plot(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space[2],Array(prob.extrapolation[1]*sol[:,1,4]))
     # savefig("MOL_1D_Linear_Diffusion_Test02.png")
 
     # Test

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -12,7 +12,7 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     @derivatives Dxx''~x
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
+    eq  = Dt(u(t,x)) ~ -Dxx(u(t,x))
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]
@@ -60,7 +60,7 @@ end
     D = 1.1
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ D*Dxx(u(t,x))
+    eq  = Dt(u(t,x)) ~ -D*Dxx(u(t,x))
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]
@@ -108,7 +108,7 @@ end
     D = 1.2
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ Dxx(D*u(t,x))
+    eq  = Dt(u(t,x)) ~ -Dxx(D*u(t,x))
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -39,16 +39,20 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    savefig("MOL_1D_Linear_Diffusion_Test00.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation*sol[1]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[2]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[3]))
+    # plot!(prob.space,Array(prob.extrapolation*sol[4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
     # Test
     n = size(sol)[1]
     t_f = size(sol)[2]
+
+    println("prob.space:",prob.space)
+    println("prob.extrapolation*sol:",prob.extrapolation*sol[t_f])
+
     @test sol[t_f] ≈ zeros(n) atol = 0.001;
 end
 
@@ -195,5 +199,3 @@ end
     t_f = size(sol)[2]
     @test sol[t_f] ≈ zeros(n) atol = 0.01;
 end
-
-

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -41,12 +41,12 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     #sol = solve(prob,,IDA(),saveat=0.1)
 
     #Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test00.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
     # Test
     n = size(sol,1)
@@ -90,12 +90,12 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test01.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test01.png")
 
     # Test
     n = size(sol,1)
@@ -143,12 +143,12 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
     
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test02.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test02.png")
 
     # Test
     n = size(sol,1)

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -1,0 +1,43 @@
+# 1D diffusion problem
+
+# Packages and inclusions
+using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra
+
+# Parameters, variables, and derivatives
+@parameters t x
+@variables u(..)
+@derivatives Dt'~t
+@derivatives Dxx''~x
+
+# 1D PDE and boundary conditions
+eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
+bcs = [u(0,x) ~ -x*(x-1)*sin(x),
+       u(t,0) ~ 0.0,
+       u(t,1) ~ 0.0]
+
+# Space and time domains
+domains = [t ∈ IntervalDomain(0.0,1.0),
+           x ∈ IntervalDomain(0.0,1.0)]
+
+# PDE system
+pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+
+# Method of lines discretization
+dx = 0.1
+order = 2
+discretization = MOLFiniteDifference(dx,order)
+
+# Convert the PDE problem into an ODE problem
+prob = discretize(pdesys,discretization)
+
+# Solve ODE problem
+using OrdinaryDiffEq
+sol = solve(prob,Tsit5(),saveat=0.1)
+
+# Plot and save results
+using Plots
+plot(prob.space,Array(prob.extrapolation*sol[1]))
+plot!(prob.space,Array(prob.extrapolation*sol[2]))
+plot!(prob.space,Array(prob.extrapolation*sol[3]))
+plot!(prob.space,Array(prob.extrapolation*sol[4]))
+savefig("MOL_1D_Linear_Difufusion.png")

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -39,21 +39,18 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation*sol[1]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[2]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[3]))
-    # plot!(prob.space,Array(prob.extrapolation*sol[4]))
-    # savefig("MOL_1D_Linear_Diffusion_Test00.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
     # Test
-    n = size(sol)[1]
-    t_f = size(sol)[2]
+    n = size(sol,1)
+    t_f = size(sol,3)
 
-    println("prob.space:",prob.space)
-    println("prob.extrapolation*sol:",prob.extrapolation*sol[t_f])
-
-    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.001;
 end
 
 @testset "Test 01: Dt(u(t,x)) ~ D*Dxx(u(t,x))" begin
@@ -90,18 +87,18 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
 
-#    # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    savefig("MOL_1D_Linear_Diffusion_Test01.png")
+    # Plot and save results
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test01.png")
 
     # Test
-    n = size(sol)[1]
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+    n = size(sol,1)
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.001;
 end
 
 @testset "Test 02: Dt(u(t,x)) ~ Dxx(D*u(t,x))" begin
@@ -138,18 +135,18 @@ end
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
 
-#    # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    savefig("MOL_1D_Linear_Diffusion_Test02.png")
+    # Plot and save results
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test02.png")
 
     # Test
-    n = size(sol)[1]
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+    n = size(sol,1)
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.001;
 end
 
 @testset "Test 03: Dt(u(t,x)) ~ Dx(D(t,x)*Dx(u(t,x)))" begin
@@ -187,15 +184,15 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-#    using Plots
-#    plot(prob.space,Array(prob.extrapolation*sol[1]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#    savefig("MOL_1D_Linear_Diffusion_Test03.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test03.png")
 
     # Test
-    n = size(sol)[1]
-    t_f = size(sol)[2]
-    @test sol[t_f] ≈ zeros(n) atol = 0.01;
+    n = size(sol,1)
+    t_f = size(sol,3)
+    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.01;
 end

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -3,46 +3,147 @@
 # Packages and inclusions
 using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
-# Parameters, variables, and derivatives
-@parameters t x
-@variables u(..)
-@derivatives Dt'~t
-@derivatives Dxx''~x
+# Tests
+@testset "Test 00: Dt(u(t,x)) ~ Dxx(u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dxx''~x
 
-# 1D PDE and boundary conditions
-eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
-bcs = [u(0,x) ~ -x*(x-1)*sin(x),
-       u(t,0) ~ 0.0,
-       u(t,1) ~ 0.0]
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
+    bcs = [u(0,x) ~ -x*(x-1)*sin(x),
+           u(t,0) ~ 0.0,
+           u(t,1) ~ 0.0]
 
-# Space and time domains
-domains = [t ∈ IntervalDomain(0.0,1.0),
-           x ∈ IntervalDomain(0.0,1.0)]
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,1.0)]
 
-# PDE system
-pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u])
 
-# Method of lines discretization
-dx = 0.1
-order = 2
-discretization = MOLFiniteDifference(dx,order)
+    # Method of lines discretization
+    dx = 0.1
+    order = 2
+    discretization = MOLFiniteDifference(dx,order)
 
-# Convert the PDE problem into an ODE problem
-prob = discretize(pdesys,discretization)
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
 
-# Solve ODE problem
-using OrdinaryDiffEq
-sol = solve(prob,Tsit5(),saveat=0.1)
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Tsit5(),saveat=0.1)
 
-# Test
-n = size(sol)[1]
-t_f = size(sol)[2]
-@test sol[t_f] ≈ zeros(n) atol = 0.001;
+#    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
-# Plot and save results
-#using Plots
-#plot(prob.space,Array(prob.extrapolation*sol[1]))
-#plot!(prob.space,Array(prob.extrapolation*sol[2]))
-#plot!(prob.space,Array(prob.extrapolation*sol[3]))
-#plot!(prob.space,Array(prob.extrapolation*sol[4]))
-#savefig("MOL_1D_Linear_Diffusion.png")
+    # Test
+    n = size(sol)[1]
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+end
+
+@testset "Test 01: Dt(u(t,x)) ~ D*Dxx(u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x D
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dxx''~x
+
+    D = 1.1
+
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ D*Dxx(u(t,x))
+    bcs = [u(0,x) ~ -x*(x-1)*sin(x),
+           u(t,0) ~ 0.0,
+           u(t,1) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,1.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x,D],[u])
+
+    # Method of lines discretization
+    dx = 0.1
+    order = 2
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Tsit5(),saveat=0.1)
+
+#    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    savefig("MOL_1D_Linear_Diffusion_Test01.png")
+
+    # Test
+    n = size(sol)[1]
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+end
+
+@testset "Test 02: Dt(u(t,x)) ~ Dxx(D*u(t,x))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x D
+    @variables u(..)
+    @derivatives Dt'~t
+    @derivatives Dxx''~x
+
+    D = 1.2
+
+    # 1D PDE and boundary conditions
+    eq  = Dt(u(t,x)) ~ Dxx(D*u(t,x))
+    bcs = [u(0,x) ~ -x*(x-1)*sin(x),
+           u(t,0) ~ 0.0,
+           u(t,1) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,1.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x,D],[u])
+
+    # Method of lines discretization
+    dx = 0.1
+    order = 2
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Tsit5(),saveat=0.1)
+
+#    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    savefig("MOL_1D_Linear_Diffusion_Test02.png")
+
+    # Test
+    n = size(sol)[1]
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+end
+
+

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -38,13 +38,15 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
 
+    #sol = solve(prob,,IDA(),saveat=0.1)
+
     #Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # savefig("MOL_1D_Linear_Diffusion_Test00.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
     # Test
     n = size(sol,1)
@@ -88,12 +90,12 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # savefig("MOL_1D_Linear_Diffusion_Test01.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test01.png")
 
     # Test
     n = size(sol,1)
@@ -101,68 +103,25 @@ end
     @test sol[:,1,t_f] ≈ zeros(n) atol = 0.001;
 end
 
-@testset "Test 02: Dt(u(t,x)) ~ Dxx(D*u(t,x))" begin
-    # Parameters, variables, and derivatives
-    @parameters t x D
-    @variables u(..)
-    @derivatives Dt'~t
-    @derivatives Dxx''~x
-
-    D = 1.2
-
-    # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ Dxx(D*u(t,x))
-    bcs = [u(0,x) ~ -x*(x-1)*sin(x),
-           u(t,0) ~ 0.0,
-           u(t,1) ~ 0.0]
-
-    # Space and time domains
-    domains = [t ∈ IntervalDomain(0.0,1.0),
-               x ∈ IntervalDomain(0.0,1.0)]
-
-    # PDE system
-    pdesys = PDESystem(eq,bcs,domains,[t,x,D],[u])
-
-    # Method of lines discretization
-    dx = 0.1
-    order = 2
-    discretization = MOLFiniteDifference(dx,order)
-
-    # Convert the PDE problem into an ODE problem
-    prob = discretize(pdesys,discretization)
-
-    # Solve ODE problem
-    using OrdinaryDiffEq
-    sol = solve(prob,Tsit5(),saveat=0.1)
-
-    # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # savefig("MOL_1D_Linear_Diffusion_Test02.png")
-
-    # Test
-    n = size(sol,1)
-    t_f = size(sol,3)
-    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.001;
-end
-
-@testset "Test 03: Dt(u(t,x)) ~ Dx(D(t,x)*Dx(u(t,x)))" begin
+@testset "Test 02: Dt(u(t,x)) ~ Dx(D(t,x))*Dx(u(t,x))+D(t,x)*Dxx(u(t,x))" begin
     # Parameters, variables, and derivatives
     @parameters t x
     @variables u(..) D(..)
     @derivatives Dt'~t
     @derivatives Dx'~x
+    @derivatives Dxx''~x
 
     # 1D PDE and boundary conditions
-    # TODO: use D(t,x) ~ t*x
-    eq  = [ Dt(u(t,x)) ~ Dx(D(t,x)*Dx(u(t,x))),
-            D(t,x) ~ 1/(1+exp(-x*t)) ]
+
+    eq  = [ Dt(u(t,x)) ~ Dx(D(t,x))*Dx(u(t,x))+D(t,x)*Dxx(u(t,x)),
+            D(t,x) ~ 0.999 + 0.001 * t * x  ]
+
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
-           u(t,1) ~ 0.0]
+           u(t,1) ~ 0.0,
+           D(0,x) ~ 0.999,
+           D(t,0) ~ 0.999,
+           D(t,1) ~ 0.999 + 0.001 * t ]
 
     # Space and time domains
     domains = [t ∈ IntervalDomain(0.0,1.0),
@@ -182,17 +141,17 @@ end
     # Solve ODE problem
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
-
+    
     # Plot and save results
-    # using Plots
-    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    # savefig("MOL_1D_Linear_Diffusion_Test03.png")
+    using Plots
+    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    savefig("MOL_1D_Linear_Diffusion_Test02.png")
 
     # Test
     n = size(sol,1)
     t_f = size(sol,3)
-    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.01;
+    @test sol[:,1,t_f] ≈ zeros(n) atol = 0.1;
 end

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -1,7 +1,7 @@
 # 1D diffusion problem
 
 # Packages and inclusions
-using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra
+using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
 
 # Parameters, variables, and derivatives
 @parameters t x
@@ -34,10 +34,15 @@ prob = discretize(pdesys,discretization)
 using OrdinaryDiffEq
 sol = solve(prob,Tsit5(),saveat=0.1)
 
+# Test
+n = size(sol)[1]
+t_f = size(sol)[2]
+@test sol[t_f] ≈ zeros(n) atol = 0.001;
+
 # Plot and save results
-using Plots
-plot(prob.space,Array(prob.extrapolation*sol[1]))
-plot!(prob.space,Array(prob.extrapolation*sol[2]))
-plot!(prob.space,Array(prob.extrapolation*sol[3]))
-plot!(prob.space,Array(prob.extrapolation*sol[4]))
-savefig("MOL_1D_Linear_Difufusion.png")
+#using Plots
+#plot(prob.space,Array(prob.extrapolation*sol[1]))
+#plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#savefig("MOL_1D_Linear_Diffusion.png")

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -12,7 +12,7 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     @derivatives Dxx''~x
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ -Dxx(u(t,x))
+    eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]
@@ -36,8 +36,8 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
 
-#    # Plot and save results
-#    using Plots
+    # Plot and save results
+    using Plots
 #    plot(prob.space,Array(prob.extrapolation*sol[1]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[2]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[3]))
@@ -60,7 +60,7 @@ end
     D = 1.1
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ -D*Dxx(u(t,x))
+    eq  = Dt(u(t,x)) ~ D*Dxx(u(t,x))
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]
@@ -108,7 +108,7 @@ end
     D = 1.2
 
     # 1D PDE and boundary conditions
-    eq  = Dt(u(t,x)) ~ -Dxx(D*u(t,x))
+    eq  = Dt(u(t,x)) ~ Dxx(D*u(t,x))
     bcs = [u(0,x) ~ -x*(x-1)*sin(x),
            u(t,0) ~ 0.0,
            u(t,1) ~ 0.0]
@@ -139,6 +139,54 @@ end
 #    plot!(prob.space,Array(prob.extrapolation*sol[3]))
 #    plot!(prob.space,Array(prob.extrapolation*sol[4]))
 #    savefig("MOL_1D_Linear_Diffusion_Test02.png")
+
+    # Test
+    n = size(sol)[1]
+    t_f = size(sol)[2]
+    @test sol[t_f] ≈ zeros(n) atol = 0.001;
+end
+
+@testset "Test 03: Dt(u(t,x)) ~ Dx(D(t,x)*Dx(u(t,x)))" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..) D(..)
+    @derivatives Dt'~t
+    @derivatives Dxx''~x
+
+    # 1D PDE and boundary conditions
+    # TODO: use D(t,x) ~ t*x
+    eq  = [ Dt(u(t,x)) ~ Dxx(D(t,x)*u(t,x)),
+            D(t,x) ~ x ]
+    bcs = [u(0,x) ~ -x*(x-1)*sin(x),
+           u(t,0) ~ 0.0,
+           u(t,1) ~ 0.0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,1.0)]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u,D])
+
+    # Method of lines discretization
+    dx = 0.1
+    order = 2
+    discretization = MOLFiniteDifference(dx,order)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
+
+    # Solve ODE problem
+    using OrdinaryDiffEq
+    sol = solve(prob,Tsit5(),saveat=0.1)
+
+    # Plot and save results
+#    using Plots
+#    plot(prob.space,Array(prob.extrapolation*sol[1]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[2]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[3]))
+#    plot!(prob.space,Array(prob.extrapolation*sol[4]))
+#    savefig("MOL_1D_Linear_Diffusion_Test03.png")
 
     # Test
     n = size(sol)[1]

--- a/test/MOL_1D_Linear_Diffusion.jl
+++ b/test/MOL_1D_Linear_Diffusion.jl
@@ -38,13 +38,13 @@ using ModelingToolkit,DiffEqOperators,DiffEqBase,LinearAlgebra,Test
     using OrdinaryDiffEq
     sol = solve(prob,Tsit5(),saveat=0.1)
 
-    # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test00.png")
+    #Plot and save results
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test00.png")
 
     # Test
     n = size(sol,1)
@@ -88,12 +88,12 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test01.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test01.png")
 
     # Test
     n = size(sol,1)
@@ -136,12 +136,12 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test02.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test02.png")
 
     # Test
     n = size(sol,1)
@@ -184,12 +184,12 @@ end
     sol = solve(prob,Tsit5(),saveat=0.1)
 
     # Plot and save results
-    using Plots
-    plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
-    plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
-    savefig("MOL_1D_Linear_Diffusion_Test03.png")
+    # using Plots
+    # plot(prob.space,Array(prob.extrapolation[1]*sol[:,1,1]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,2]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,3]))
+    # plot!(prob.space,Array(prob.extrapolation[1]*sol[:,1,4]))
+    # savefig("MOL_1D_Linear_Diffusion_Test03.png")
 
     # Test
     n = size(sol,1)

--- a/test/MOLtest.jl
+++ b/test/MOLtest.jl
@@ -7,7 +7,7 @@ using ModelingToolkit, DiffEqOperators, DiffEqBase, LinearAlgebra
 @derivatives Dxx''~x
 eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
 bcs = [u(0,x) ~ - x * (x-1) * sin(x),
-           u(t,0) ~ 0, u(t,1) ~ 0]
+       u(t,0) ~ 0.0, u(t,1) ~ 0.0]
 
 domains = [t ∈ IntervalDomain(0.0,1.0),
            x ∈ IntervalDomain(0.0,1.0)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,8 @@ if GROUP == "All" || GROUP == "Interface"
     @time @safetestset "Coefficient Functions" begin include("coefficient_functions.jl") end
     @time @safetestset "Upwind Operator Interface" begin include("upwind_operators_interface.jl") end
     @time @safetestset "MOLFiniteDifference Interface" begin include("MOLtest.jl") end
+    @time @safetestset "MOLFiniteDifference Interface: Linear Convection" begin include("MOL_1D_Linear_Convection.jl") end
+    @time @safetestset "MOLFiniteDifference Interface: Linear Diffusion" begin include("MOL_1D_Linear_Diffusion.jl") end
     @time @safetestset "Basic SDO Examples" begin include("BasicSDOExamples.jl") end
     # @time @safetestset "Linear Complementarity Problem Examples" begin include("lcp.jl"); include("lcp_split.jl") end
 end


### PR DESCRIPTION
### One-dimensional PDE auto-discretization using finite-difference (work in progress)
- Current PR is associated to issue: https://github.com/SciML/DifferentialEquations.jl/issues/469
- Auto-discretization code is located in src/MOL_discretization.jl. Tests are located in test/ directory.
- The following 1D CFD cases are supported, nonetheless more testing is needed.
    - Typical cases of the 1D diffusion equation:
        - [x] Dt(u(t,x)) ~ Dxx(u(t,x))
        - [x] Dt(u(t,x)) ~ D*Dxx(u(t,x))
        - [x] Dt(u(t,x)) ~ Dx(D(t,x))*Dx(u(t,x))+D(t,x)*Dxx(u(t,x))
    - Typical cases of the 1D convection equation:
        - [x] Dt(u(t,x)) ~ -Dx(u(t,x))
        - [x] Dt(u(t,x)) ~ -Dx(u(t,x)) + S, S is constant
        - [x] Dt(u(t,x)) ~ -v*Dx(u(t,x)), v is constant
        - [x] Dt(u(t,x)) ~ -Dx(v(t,x))*u(t,x)-v(t,x)*Dx(u(t,x)), v(t,x)=1
        - [x] Dt(u(t,x)) ~ -Dx(v(t,x))*u(t,x)-v(t,x)*Dx(u(t,x)), v(t,x)=0.999 + 0.001 * t * x 
    - Typical cases of 1D diffusion-convection equation:
        - [x] Dt(u(t,x)) ~ Dxx(u(t,x))-v*Dx(u(t,x))
    - Source/sink term
        - [x] All cases above support a constant source/sink term in rhs
        - [x] All cases above support a source/sink term which depends on (t,x) in rhs
    - Boundary conditions
        - [x] All cases above support Dirichlet boundary conditions