### PR TITLE
Add operator combination with AbstractMatrix and UniformScaling

### DIFF
--- a/src/composite_operators.jl
+++ b/src/composite_operators.jl
@@ -20,10 +20,18 @@ struct DiffEqOperatorCombination{T,O<:Tuple{Vararg{AbstractDiffEqLinearOperator{
     end
 end
 +(ops::AbstractDiffEqLinearOperator...) = DiffEqOperatorCombination(ops)
++(op::AbstractDiffEqLinearOperator, A::AbstractMatrix) = op + DiffEqArrayOperator(A)
++(op::AbstractDiffEqLinearOperator{T}, α::UniformScaling) where T = op + DiffEqArrayOperator(UniformScaling(T(α.λ))(size(op,1)))
++(A::AbstractMatrix, op::AbstractDiffEqLinearOperator) = op + A
++(α::UniformScaling, op::AbstractDiffEqLinearOperator) = op + α
 +(L1::DiffEqOperatorCombination, L2::AbstractDiffEqLinearOperator) = DiffEqOperatorCombination((L1.ops..., L2))
 +(L1::AbstractDiffEqLinearOperator, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1, L2.ops...))
 +(L1::DiffEqOperatorCombination, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1.ops..., L2.ops...))
 -(L1::AbstractDiffEqLinearOperator, L2::AbstractDiffEqLinearOperator) = L1 + (-L2)
+-(L::AbstractDiffEqLinearOperator, A::AbstractMatrix) = L + (-A)
+-(A::AbstractMatrix, L::AbstractDiffEqLinearOperator) = A + (-L)
+-(L::AbstractDiffEqLinearOperator, α::UniformScaling) = L + (-α)
+-(α::UniformScaling, L::AbstractDiffEqLinearOperator) = α + (-L)
 getops(L::DiffEqOperatorCombination) = L.ops
 Matrix(L::DiffEqOperatorCombination) = sum(Matrix, L.ops)
 convert(::Type{AbstractMatrix}, L::DiffEqOperatorCombination) =

--- a/src/composite_operators.jl
+++ b/src/composite_operators.jl
@@ -21,7 +21,7 @@ struct DiffEqOperatorCombination{T,O<:Tuple{Vararg{AbstractDiffEqLinearOperator{
 end
 +(ops::AbstractDiffEqLinearOperator...) = DiffEqOperatorCombination(ops)
 +(op::AbstractDiffEqLinearOperator, A::AbstractMatrix) = op + DiffEqArrayOperator(A)
-+(op::AbstractDiffEqLinearOperator{T}, α::UniformScaling) where T = op + DiffEqArrayOperator(UniformScaling(T(α.λ))(size(op,1)))
++(op::AbstractDiffEqLinearOperator{T}, α::UniformScaling) where T = op + UniformScaling(T(α.λ))(size(op,1))
 +(A::AbstractMatrix, op::AbstractDiffEqLinearOperator) = op + A
 +(α::UniformScaling, op::AbstractDiffEqLinearOperator) = op + α
 +(L1::DiffEqOperatorCombination, L2::AbstractDiffEqLinearOperator) = DiffEqOperatorCombination((L1.ops..., L2))

--- a/test/DerivativeOperators/composite_operators_interface.jl
+++ b/test/DerivativeOperators/composite_operators_interface.jl
@@ -3,25 +3,19 @@ using DiffEqBase
 using DiffEqBase: isconstant
 using DiffEqOperators: DiffEqScaledOperator, DiffEqOperatorCombination, DiffEqOperatorComposition
 
-@testset "Operator Compostion" begin
+@testset "Operator Composition" begin
   Random.seed!(0)
   A1 = rand(2,3)
   A2 = rand(3,2)
   b = rand()
   B = rand(2,2)
-  L0 = DiffEqArrayOperator(Diagonal([1.0, 1.0])) - I + zeros(2, 2) # this operator is 0
-  L = DiffEqArrayOperator(A1) * DiffEqArrayOperator(A2) + DiffEqScalar(b) * DiffEqArrayOperator(B) + L0
+  L = DiffEqArrayOperator(A1) * DiffEqArrayOperator(A2) + DiffEqScalar(b) * DiffEqArrayOperator(B)
 
   # Structure
   @test isa(L, DiffEqOperatorCombination)
-  L1, L2, L3 = getops(L)
+  L1, L2 = getops(L)
   @test isa(L1, DiffEqOperatorComposition)
   @test isa(L2, DiffEqScaledOperator)
-  @test isa(L3, DiffEqOperatorCombination)
-
-  # Verify that L3 and L0 == 0
-  @test all(Matrix(L3) .== 0)
-  @test all(Matrix(L0) .== 0)
 
   # Operations
   Lfull = Matrix(L)
@@ -34,6 +28,16 @@ using DiffEqOperators: DiffEqScaledOperator, DiffEqOperatorCombination, DiffEqOp
   Lf = factorize(L)
   ldiv!(du, Lf, u); @test Lfull * du ≈ u
   @test exp(L) ≈ exp(Lfull)
+end
+
+@testset "Operator combinations" begin
+  Random.seed!(0)
+  A = rand(2,2)
+  L1 = DiffEqArrayOperator(A)
+  @testset "" for op in (+,-), L2 in (L1,A,I)
+    @test isa(op(L1, L2), DiffEqOperatorCombination)
+    @test isa(op(L2, L1), DiffEqOperatorCombination)
+  end
 end
 
 @testset "Mutable Composite Operators" begin

--- a/test/DerivativeOperators/composite_operators_interface.jl
+++ b/test/DerivativeOperators/composite_operators_interface.jl
@@ -9,13 +9,19 @@ using DiffEqOperators: DiffEqScaledOperator, DiffEqOperatorCombination, DiffEqOp
   A2 = rand(3,2)
   b = rand()
   B = rand(2,2)
-  L = DiffEqArrayOperator(A1) * DiffEqArrayOperator(A2) + DiffEqScalar(b) * DiffEqArrayOperator(B)
+  L0 = DiffEqArrayOperator(Diagonal([1.0, 1.0])) - I + zeros(2, 2) # this operator is 0
+  L = DiffEqArrayOperator(A1) * DiffEqArrayOperator(A2) + DiffEqScalar(b) * DiffEqArrayOperator(B) + L0
 
   # Structure
   @test isa(L, DiffEqOperatorCombination)
-  L1, L2 = getops(L)
+  L1, L2, L3 = getops(L)
   @test isa(L1, DiffEqOperatorComposition)
   @test isa(L2, DiffEqScaledOperator)
+  @test isa(L3, DiffEqOperatorCombination)
+
+  # Verify that L3 and L0 == 0
+  @test all(Matrix(L3) .== 0)
+  @test all(Matrix(L0) .== 0)
 
   # Operations
   Lfull = Matrix(L)


### PR DESCRIPTION
This PR adds functionality to add `AbstractMatrix` and `UniformScaling` objects to linear operators.

E.g., with this PR you can do
```julia
A = rand(2,2)
B = rand(2,2)
OP = DiffEqArrayOperator(A)
L = OP + B # converts B into a DiffEqArrayOperator before combining them
L = OP + 2I # converts 2I into a diagonal matrix and then applies the rule above
OP = DiffEqArrayOperator(sparse(A))
L = OP + 2I # Also works for sparse operators!
```

I added some dummy tests, but I'm not sure what else I should do. Please let me know!