### PR TITLE
Generalizing MOLFiniteDifference to N-order PDEs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 BandedMatrices = "0.15.11, 0.16"

--- a/src/MOLFiniteDifference/MOL_discretization.jl
+++ b/src/MOLFiniteDifference/MOL_discretization.jl
@@ -110,9 +110,6 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
     # Count the number of boundary equations that lie at the spatial boundary on
     # both the left and right side. This will be used to determine number of
     # interior equations s.t. we have a balanced system of equations.
-    # TODO: Check/Generalize to work with multi-dimensional equations
-    # TODO: Check Generalization to higher order boundary conditions (e.g., beam equation with 2nd order/3rd order boundary)
-    # TODO: Check against equations with multiple dependent vars
 
     # get the depvar boundary terms for given depvar and indvar index.
     get_depvarbcs(depvar, i) = substitute.((depvar,),get_edgevals(i))

--- a/src/MOLFiniteDifference/MOL_discretization.jl
+++ b/src/MOLFiniteDifference/MOL_discretization.jl
@@ -130,6 +130,9 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
         central_neighbor_space(II,j) = vec(space[j][map(i->i[j],central_neighbor_idxs(II,j))])
         central_weights(d_order,II,j) = DiffEqOperators.calculate_weights(d_order, space[j][II[j]], central_neighbor_space(II,j))
         central_deriv(d_order,II,j,k) = dot(central_weights(d_order,II,j),depvarsdisc[k][central_neighbor_idxs(II,j)])
+
+        # get a sorted list derivative order such that highest order is first. This is useful when substituting rules
+        # starting from highest to lowest order.
         d_orders(s) = reverse(sort(collect(union(differential_order(eq.rhs, s.val), differential_order(eq.lhs, s.val)))))
 
         # central_deriv_rules = [(Differential(s)^2)(u) => central_deriv(2,II,j,k) for (j,s) in enumerate(nottime), (k,u) in enumerate(depvars)]

--- a/src/MOLFiniteDifference/MOL_discretization.jl
+++ b/src/MOLFiniteDifference/MOL_discretization.jl
@@ -195,7 +195,7 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
         # Use max and min to apply buffers
         central_neighbor_idxs(II,j) = stencil(j) .+ max(Imin,min(II,Imax))
         central_neighbor_space(II,j) = vec(grid[j][map(i->i[j],central_neighbor_idxs(II,j))])
-        central_weights(d_order, II,j) = DiffEqOperators.calculate_weights(2, grid[j][II[j]], central_neighbor_space(II,j))
+        central_weights(d_order, II,j) = DiffEqOperators.calculate_weights(d_order, grid[j][II[j]], central_neighbor_space(II,j))
         central_deriv(d_order, II,j,k) = dot(central_weights(d_order, II,j),depvarsdisc[k][central_neighbor_idxs(II,j)])
 
         # get a sorted list derivative order such that highest order is first. This is useful when substituting rules

--- a/src/MOLFiniteDifference/MOL_discretization.jl
+++ b/src/MOLFiniteDifference/MOL_discretization.jl
@@ -113,7 +113,7 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
         # Create a stencil in the required dimension centered around 0
         # e.g. (-1,0,1) for 2nd order, (-2,-1,0,1,2) for 4th order, etc
         if discretization.centered_order % 2 != 0
-            throw(ArgumentError, "Discretization centered_order must be even, given $(discretization.centered_order)")
+            throw(ArgumentError("Discretization centered_order must be even, given $(discretization.centered_order)"))
         end
         approx_order = discretization.centered_order
         stencil(j) = CartesianIndices(Tuple(map(x -> -x:x, (1:nspace.==j) * (approx_order÷2))))

--- a/src/MOLFiniteDifference/MOL_discretization.jl
+++ b/src/MOLFiniteDifference/MOL_discretization.jl
@@ -112,6 +112,9 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
     
         # Create a stencil in the required dimension centered around 0
         # e.g. (-1,0,1) for 2nd order, (-2,-1,0,1,2) for 4th order, etc
+        if discretization.centered_order % 2 != 0
+            throw(ArgumentError, "Discretization centered_order must be even, given $(discretization.centered_order)")
+        end
         order = discretization.centered_order
         stencil(j) = CartesianIndices(Tuple(map(x -> -x:x, (1:nspace.==j) * (order÷2))))
     

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,6 +21,23 @@ function cartesian_to_linear(I::CartesianIndex, s)  #Not sure if there is a buil
     return out
 end
 
+# Counts the Differential operators for given variable x. This is used to determine
+# the order of a PDE.
+function count_differentials(term, x::Symbolics.Symbolic)
+    S = Symbolics
+    SU = SymbolicUtils
+    if !S.istree(term)
+        return 0
+    else
+        op = SU.operation(term)
+        count_children = sum(map(arg -> count_differentials(arg, x), SU.arguments(term)))
+        if op isa Differential && op.x === x
+            return 1 + count_children
+        end
+        return count_children
+    end
+end
+
 add_dims(A::AbstractArray, n::Int; dims::Int = 1) = cat(ndims(A) + n, A, dims = dims)
 
 ""

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,4 @@
+using SymbolicUtils
 
 """
 A function that creates a tuple of CartesianIndices of unit length and `N` dimensions, one pointing along each dimension.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,6 +38,24 @@ function count_differentials(term, x::Symbolics.Symbolic)
     end
 end
 
+# return list of differential orders in the equation
+function differential_order(eq, x::Symbolics.Symbolic)
+    S = Symbolics
+    SU = SymbolicUtils
+    orders = Set{Int}()
+    if S.istree(eq)
+        op = SU.operation(eq)
+        if op isa Differential
+            push!(orders, count_differentials(eq, x))
+        else
+            for o in map(ch -> differential_order(ch, x), SU.arguments(eq))
+                union!(orders, o)
+            end
+        end
+    end
+    return filter(!iszero, orders)
+end
+
 add_dims(A::AbstractArray, n::Int; dims::Int = 1) = cat(ndims(A) + n, A, dims = dims)
 
 ""

--- a/test/MOL/MOL_1D_HigherOrder.jl
+++ b/test/MOL/MOL_1D_HigherOrder.jl
@@ -103,11 +103,14 @@ end
     # Discretization
     dx = 0.4; dt = 0.2
 
-    discretization = MOLFiniteDifference([x=>dx],t;centered_order=4)
+    discretization = MOLFiniteDifference([x=>dx],t;centered_order=4,grid_align=center_align)
     pdesys = PDESystem(eq,bcs,domains,[x,t],[u(x,t)])
     prob = discretize(pdesys,discretization)
 
     sol = solve(prob,Tsit5(),saveat=0.1,dt=dt)
+
+    @test sol.retcode == :Success
+
     xs = domains[1].domain.lower+dx+dx:dx:domains[1].domain.upper-dx-dx
     ts = sol.t
 

--- a/test/MOL/MOL_1D_HigherOrder.jl
+++ b/test/MOL/MOL_1D_HigherOrder.jl
@@ -36,8 +36,16 @@ using ModelingToolkit: Differential
     dx = 0.4; dt = 0.2
 
     discretization = MOLFiniteDifference([x=>dx],t;centered_order=4)
-    pde_system = PDESystem(eq,bcs,domains,[x,t],[u(x,t)])
-    prob = discretize(pde_system,discretization)
+    pdesys = PDESystem(eq,bcs,domains,[x,t],[u(x,t)])
+    prob = discretize(pdesys,discretization)
 
-    # TODO: finish this.
+    sol = solve(prob,Tsit5(),saveat=0.1,dt=dt)
+    xs = domains[1].domain.lower+dx+dx:dx:domains[1].domain.upper-dx-dx
+    ts = sol.t
+
+    u_predict = sol.u
+    u_real = [[u_analytic(x, t) for x in xs] for t in ts]
+    u_diff = u_real - u_predict
+    @test_broken u_diff[:] ≈ zeros(length(u_diff)) atol=0.01;
+    #plot(xs, u_diff)
 end

--- a/test/MOL/MOL_1D_HigherOrder.jl
+++ b/test/MOL/MOL_1D_HigherOrder.jl
@@ -4,73 +4,73 @@
 using ModelingToolkit,DiffEqOperators,LinearAlgebra,Test,OrdinaryDiffEq
 using ModelingToolkit: Differential
 
-@testset "Beam Equation" begin
-    @parameters x, t
-    @variables u(..)
-    Dt = Differential(t)
-    Dtt = Differential(t)^2
-    Dx = Differential(x)
-    Dxx = Differential(x)^2
-    Dx3 = Differential(x)^3
-    Dx4 = Differential(x)^4
+# @testset "Beam Equation" begin
+#     @parameters x, t
+#     @variables u(..)
+#     Dt = Differential(t)
+#     Dtt = Differential(t)^2
+#     Dx = Differential(x)
+#     Dxx = Differential(x)^2
+#     Dx3 = Differential(x)^3
+#     Dx4 = Differential(x)^4
 
-    g = -9.81
-    EI = 1
-    mu = 1
-    L = 10.0
-    dx = 0.4
+#     g = -9.81
+#     EI = 1
+#     mu = 1
+#     L = 10.0
+#     dx = 0.4
 
-    eq = Dtt(u(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g
+#     eq = Dtt(u(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g
 
-    bcs = [u(0, x) ~ 0,
-           u(t,0) ~ 0,
-           Dx(u(t,0)) ~ 0,
-           Dxx(u(t, L)) ~ 0,
-           Dx3(u(t, L)) ~ 0]
+#     bcs = [u(0, x) ~ 0,
+#            u(t,0) ~ 0,
+#            Dx(u(t,0)) ~ 0,
+#            Dxx(u(t, L)) ~ 0,
+#            Dx3(u(t, L)) ~ 0]
 
-    # Space and time domains
-    domains = [t ∈ IntervalDomain(0.0,1.0),
-               x ∈ IntervalDomain(0.0,L)]
+#     # Space and time domains
+#     domains = [t ∈ IntervalDomain(0.0,1.0),
+#                x ∈ IntervalDomain(0.0,L)]
 
-    pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
-    discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
-    prob = discretize(pdesys,discretization)
-end
+#     pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
+#     discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
+#     prob = discretize(pdesys,discretization)
+# end
 
-@testset "Beam Equation with Velocity" begin
-    @parameters x, t
-    @variables u(..), v(..)
-    Dt = Differential(t)
-    Dtt = Differential(t)^2
-    Dx = Differential(x)
-    Dxx = Differential(x)^2
-    Dx3 = Differential(x)^3
-    Dx4 = Differential(x)^4
+# @testset "Beam Equation with Velocity" begin
+#     @parameters x, t
+#     @variables u(..), v(..)
+#     Dt = Differential(t)
+#     Dtt = Differential(t)^2
+#     Dx = Differential(x)
+#     Dxx = Differential(x)^2
+#     Dx3 = Differential(x)^3
+#     Dx4 = Differential(x)^4
 
-    g = -9.81
-    EI = 1
-    mu = 1
-    L = 10.0
-    dx = 0.4
+#     g = -9.81
+#     EI = 1
+#     mu = 1
+#     L = 10.0
+#     dx = 0.4
 
-    eqs = [v(t, x) ~ Dt(u(t,x)),
-           Dt(v(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g]
+#     eqs = [v(t, x) ~ Dt(u(t,x)),
+#            Dt(v(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g]
 
-    bcs = [u(0, x) ~ 0,
-           v(0, x) ~ 0,
-           u(t,0) ~ 0,
-           v(t,0) ~ 0,
-           Dxx(u(t, L)) ~ 0,
-           Dx3(u(t, L)) ~ 0]
+#     bcs = [u(0, x) ~ 0,
+#            v(0, x) ~ 0,
+#            u(t,0) ~ 0,
+#            v(t,0) ~ 0,
+#            Dxx(u(t, L)) ~ 0,
+#            Dx3(u(t, L)) ~ 0]
 
-    # Space and time domains
-    domains = [t ∈ IntervalDomain(0.0,1.0),
-               x ∈ IntervalDomain(0.0,L)]
+#     # Space and time domains
+#     domains = [t ∈ IntervalDomain(0.0,1.0),
+#                x ∈ IntervalDomain(0.0,L)]
 
-    pdesys = PDESystem(eqs,bcs,domains,[t,x],[u(t,x),v(t,x)])
-    discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
-    prob = discretize(pdesys,discretization)
-end
+#     pdesys = PDESystem(eqs,bcs,domains,[t,x],[u(t,x),v(t,x)])
+#     discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
+#     prob = discretize(pdesys,discretization)
+# end
 
 @testset "Kuramoto–Sivashinsky equation" begin
     @parameters x, t

--- a/test/MOL/MOL_1D_HigherOrder.jl
+++ b/test/MOL/MOL_1D_HigherOrder.jl
@@ -1,0 +1,43 @@
+# 1D diffusion problem
+
+# TODO: Add more complex tests.
+
+# Packages and inclusions
+using ModelingToolkit,DiffEqOperators,LinearAlgebra,Test,OrdinaryDiffEq
+using ModelingToolkit: Differential
+
+@testset "Kuramoto–Sivashinsky equation" begin
+    @parameters x, t
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dx2 = Differential(x)^2
+    Dx3 = Differential(x)^3
+    Dx4 = Differential(x)^4
+
+    α = 1
+    β = 4
+    γ = 1
+    eq = Dt(u(x,t)) ~ -u(x,t)*Dx(u(x,t)) - α*Dx2(u(x,t)) - β*Dx3(u(x,t)) - γ*Dx4(u(x,t))
+
+    u_analytic(x,t;z = -x/2+t) = 11 + 15*tanh(z) -15*tanh(z)^2 - 15*tanh(z)^3
+    du(x,t;z = -x/2+t) = 15/2*(tanh(z) + 1)*(3*tanh(z) - 1)*sech(z)^2
+
+    bcs = [u(x,0) ~ u_analytic(x,0),
+           u(-10,t) ~ u_analytic(-10,t),
+           u(10,t) ~ u_analytic(10,t),
+           Dx(u(-10,t)) ~ du(-10,t),
+           Dx(u(10,t)) ~ du(10,t)]
+
+    # Space and time domains
+    domains = [x ∈ IntervalDomain(-10.0,10.0),
+               t ∈ IntervalDomain(0.0,1.0)]
+    # Discretization
+    dx = 0.4; dt = 0.2
+
+    discretization = MOLFiniteDifference([x=>dx],t;centered_order=4)
+    pde_system = PDESystem(eq,bcs,domains,[x,t],[u(x,t)])
+    prob = discretize(pde_system,discretization)
+
+    # TODO: finish this.
+end

--- a/test/MOL/MOL_1D_HigherOrder.jl
+++ b/test/MOL/MOL_1D_HigherOrder.jl
@@ -4,73 +4,75 @@
 using ModelingToolkit,DiffEqOperators,LinearAlgebra,Test,OrdinaryDiffEq
 using ModelingToolkit: Differential
 
-# @testset "Beam Equation" begin
-#     @parameters x, t
-#     @variables u(..)
-#     Dt = Differential(t)
-#     Dtt = Differential(t)^2
-#     Dx = Differential(x)
-#     Dxx = Differential(x)^2
-#     Dx3 = Differential(x)^3
-#     Dx4 = Differential(x)^4
+# Beam Equation
+@test_broken begin
+    @parameters x, t
+    @variables u(..)
+    Dt = Differential(t)
+    Dtt = Differential(t)^2
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
+    Dx3 = Differential(x)^3
+    Dx4 = Differential(x)^4
 
-#     g = -9.81
-#     EI = 1
-#     mu = 1
-#     L = 10.0
-#     dx = 0.4
+    g = -9.81
+    EI = 1
+    mu = 1
+    L = 10.0
+    dx = 0.4
 
-#     eq = Dtt(u(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g
+    eq = Dtt(u(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g
 
-#     bcs = [u(0, x) ~ 0,
-#            u(t,0) ~ 0,
-#            Dx(u(t,0)) ~ 0,
-#            Dxx(u(t, L)) ~ 0,
-#            Dx3(u(t, L)) ~ 0]
+    bcs = [u(0, x) ~ 0,
+           u(t,0) ~ 0,
+           Dx(u(t,0)) ~ 0,
+           Dxx(u(t, L)) ~ 0,
+           Dx3(u(t, L)) ~ 0]
 
-#     # Space and time domains
-#     domains = [t ∈ IntervalDomain(0.0,1.0),
-#                x ∈ IntervalDomain(0.0,L)]
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,L)]
 
-#     pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
-#     discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
-#     prob = discretize(pdesys,discretization)
-# end
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
+    discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
+    prob = discretize(pdesys,discretization)
+end
 
-# @testset "Beam Equation with Velocity" begin
-#     @parameters x, t
-#     @variables u(..), v(..)
-#     Dt = Differential(t)
-#     Dtt = Differential(t)^2
-#     Dx = Differential(x)
-#     Dxx = Differential(x)^2
-#     Dx3 = Differential(x)^3
-#     Dx4 = Differential(x)^4
+# Beam Equation with Velocity
+@test_broken begin
+    @parameters x, t
+    @variables u(..), v(..)
+    Dt = Differential(t)
+    Dtt = Differential(t)^2
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
+    Dx3 = Differential(x)^3
+    Dx4 = Differential(x)^4
 
-#     g = -9.81
-#     EI = 1
-#     mu = 1
-#     L = 10.0
-#     dx = 0.4
+    g = -9.81
+    EI = 1
+    mu = 1
+    L = 10.0
+    dx = 0.4
 
-#     eqs = [v(t, x) ~ Dt(u(t,x)),
-#            Dt(v(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g]
+    eqs = [v(t, x) ~ Dt(u(t,x)),
+           Dt(v(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g]
 
-#     bcs = [u(0, x) ~ 0,
-#            v(0, x) ~ 0,
-#            u(t,0) ~ 0,
-#            v(t,0) ~ 0,
-#            Dxx(u(t, L)) ~ 0,
-#            Dx3(u(t, L)) ~ 0]
+    bcs = [u(0, x) ~ 0,
+           v(0, x) ~ 0,
+           u(t,0) ~ 0,
+           v(t,0) ~ 0,
+           Dxx(u(t, L)) ~ 0,
+           Dx3(u(t, L)) ~ 0]
 
-#     # Space and time domains
-#     domains = [t ∈ IntervalDomain(0.0,1.0),
-#                x ∈ IntervalDomain(0.0,L)]
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,L)]
 
-#     pdesys = PDESystem(eqs,bcs,domains,[t,x],[u(t,x),v(t,x)])
-#     discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
-#     prob = discretize(pdesys,discretization)
-# end
+    pdesys = PDESystem(eqs,bcs,domains,[t,x],[u(t,x),v(t,x)])
+    discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
+    prob = discretize(pdesys,discretization)
+end
 
 @testset "Kuramoto–Sivashinsky equation" begin
     @parameters x, t

--- a/test/MOL/MOL_1D_HigherOrder.jl
+++ b/test/MOL/MOL_1D_HigherOrder.jl
@@ -1,10 +1,76 @@
 # 1D diffusion problem
 
-# TODO: Add more complex tests.
-
 # Packages and inclusions
 using ModelingToolkit,DiffEqOperators,LinearAlgebra,Test,OrdinaryDiffEq
 using ModelingToolkit: Differential
+
+@testset "Beam Equation" begin
+    @parameters x, t
+    @variables u(..)
+    Dt = Differential(t)
+    Dtt = Differential(t)^2
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
+    Dx3 = Differential(x)^3
+    Dx4 = Differential(x)^4
+
+    g = -9.81
+    EI = 1
+    mu = 1
+    L = 10.0
+    dx = 0.4
+
+    eq = Dtt(u(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g
+
+    bcs = [u(0, x) ~ 0,
+           u(t,0) ~ 0,
+           Dx(u(t,0)) ~ 0,
+           Dxx(u(t, L)) ~ 0,
+           Dx3(u(t, L)) ~ 0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,L)]
+
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
+    discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
+    prob = discretize(pdesys,discretization)
+end
+
+@testset "Beam Equation with Velocity" begin
+    @parameters x, t
+    @variables u(..), v(..)
+    Dt = Differential(t)
+    Dtt = Differential(t)^2
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
+    Dx3 = Differential(x)^3
+    Dx4 = Differential(x)^4
+
+    g = -9.81
+    EI = 1
+    mu = 1
+    L = 10.0
+    dx = 0.4
+
+    eqs = [v(t, x) ~ Dt(u(t,x)),
+           Dt(v(t,x)) ~ -mu*EI*Dx4(u(t,x)) + mu*g]
+
+    bcs = [u(0, x) ~ 0,
+           v(0, x) ~ 0,
+           u(t,0) ~ 0,
+           v(t,0) ~ 0,
+           Dxx(u(t, L)) ~ 0,
+           Dx3(u(t, L)) ~ 0]
+
+    # Space and time domains
+    domains = [t ∈ IntervalDomain(0.0,1.0),
+               x ∈ IntervalDomain(0.0,L)]
+
+    pdesys = PDESystem(eqs,bcs,domains,[t,x],[u(t,x),v(t,x)])
+    discretization = MOLFiniteDifference([x=>dx],t, centered_order=4)
+    prob = discretize(pdesys,discretization)
+end
 
 @testset "Kuramoto–Sivashinsky equation" begin
     @parameters x, t

--- a/test/Misc/utils.jl
+++ b/test/Misc/utils.jl
@@ -7,3 +7,46 @@ using DiffEqOperators
     @test DiffEqOperators.perpindex(collect(1:5), 3) == [1, 2, 4, 5]
     @test DiffEqOperators.perpsize(zeros(2,2,3,2), 3) == (2, 2, 2)
 end
+
+@testset "count differentials 1D" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+
+    Dx = Differential(x)
+    eq  = Dt(u(t,x)) ~ -Dx(u(t,x))
+    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 1
+    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
+    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
+    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+
+    Dxx = Differential(x)^2
+    eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
+    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 2
+    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
+    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
+    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+
+    Dxxxx = Differential(x)^4
+    eq  = Dt(u(t,x)) ~ -Dxxxx(u(t,x))
+    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 4
+    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
+    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
+    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+end
+
+@testset "count differentials 2D" begin
+    @parameters t x y
+    @variables u(..)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    Dt = Differential(t)
+
+    eq  = Dt(u(t,x,y)) ~ Dxx(u(t,x,y)) + Dyy(u(t,x,y))
+    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 2
+    @test DiffEqOperators.count_differentials(eq.rhs, y.val) == 2
+    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
+    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
+    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+    @test DiffEqOperators.count_differentials(eq.lhs, y.val) == 0
+end

--- a/test/Misc/utils.jl
+++ b/test/Misc/utils.jl
@@ -80,8 +80,3 @@ end
     eq = Dt(u(x,t)) + u(x,t)*Dx(u(x,t)) + α*Dx2(u(x,t)) + β*Dx3(u(x,t)) + γ*Dx4(u(x,t)) ~ 0
     @test DiffEqOperators.differential_order(eq.lhs, x.val) == Set([4, 3, 2, 1])
 end
-
-# mixed terms DxDy, DxxDyy
-# Sum of terms Dx, Dxx, Dxxx
-# SUm of terms with multivar
-# ks equation

--- a/test/Misc/utils.jl
+++ b/test/Misc/utils.jl
@@ -1,5 +1,6 @@
 using Test, LinearAlgebra
 using DiffEqOperators
+using ModelingToolkit
 
 @testset "utility functions" begin
     @test DiffEqOperators.unit_indices(2) == (CartesianIndex(1,0), CartesianIndex(0,1))

--- a/test/Misc/utils.jl
+++ b/test/Misc/utils.jl
@@ -15,24 +15,24 @@ end
 
     Dx = Differential(x)
     eq  = Dt(u(t,x)) ~ -Dx(u(t,x))
-    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 1
-    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
-    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
-    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+    @test first(DiffEqOperators.differential_order(eq.rhs, x.val)) == 1
+    @test isempty(DiffEqOperators.differential_order(eq.rhs, t.val))
+    @test first(DiffEqOperators.differential_order(eq.lhs, t.val)) == 1
+    @test isempty(DiffEqOperators.differential_order(eq.lhs, x.val))
 
     Dxx = Differential(x)^2
     eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
-    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 2
-    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
-    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
-    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+    @test first(DiffEqOperators.differential_order(eq.rhs, x.val)) == 2
+    @test isempty(DiffEqOperators.differential_order(eq.rhs, t.val))
+    @test first(DiffEqOperators.differential_order(eq.lhs, t.val)) == 1
+    @test isempty(DiffEqOperators.differential_order(eq.lhs, x.val))
 
     Dxxxx = Differential(x)^4
     eq  = Dt(u(t,x)) ~ -Dxxxx(u(t,x))
-    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 4
-    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
-    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
-    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
+    @test first(DiffEqOperators.differential_order(eq.rhs, x.val)) == 4
+    @test isempty(DiffEqOperators.differential_order(eq.rhs, t.val))
+    @test first(DiffEqOperators.differential_order(eq.lhs, t.val)) == 1
+    @test isempty(DiffEqOperators.differential_order(eq.lhs, x.val))
 end
 
 @testset "count differentials 2D" begin
@@ -43,10 +43,45 @@ end
     Dt = Differential(t)
 
     eq  = Dt(u(t,x,y)) ~ Dxx(u(t,x,y)) + Dyy(u(t,x,y))
-    @test DiffEqOperators.count_differentials(eq.rhs, x.val) == 2
-    @test DiffEqOperators.count_differentials(eq.rhs, y.val) == 2
-    @test DiffEqOperators.count_differentials(eq.rhs, t.val) == 0
-    @test DiffEqOperators.count_differentials(eq.lhs, t.val) == 1
-    @test DiffEqOperators.count_differentials(eq.lhs, x.val) == 0
-    @test DiffEqOperators.count_differentials(eq.lhs, y.val) == 0
+    @test first(DiffEqOperators.differential_order(eq.rhs, x.val)) == 2
+    @test first(DiffEqOperators.differential_order(eq.rhs, y.val)) == 2
+    @test isempty(DiffEqOperators.differential_order(eq.rhs, t.val))
+    @test first(DiffEqOperators.differential_order(eq.lhs, t.val)) == 1
+    @test isempty(DiffEqOperators.differential_order(eq.lhs, x.val))
+    @test isempty(DiffEqOperators.differential_order(eq.lhs, y.val))
 end
+
+@testset "count with mixed terms" begin
+    @parameters t x y
+    @variables u(..)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    Dx = Differential(x)
+    Dy = Differential(y)
+    Dt = Differential(t)
+
+    eq  = Dt(u(t,x,y)) ~ Dxx(u(t,x,y)) + Dyy(u(t,x,y)) + Dx(Dy(u(t,x,y)))
+    @test DiffEqOperators.differential_order(eq.rhs, x.val) == Set([2, 1])
+    @test DiffEqOperators.differential_order(eq.rhs, y.val) == Set([2, 1])
+end
+
+@testset "Kuramoto–Sivashinsky equation" begin
+    @parameters x, t
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dx2 = Differential(x)^2
+    Dx3 = Differential(x)^3
+    Dx4 = Differential(x)^4
+
+    α = 1
+    β = 4
+    γ = 1
+    eq = Dt(u(x,t)) + u(x,t)*Dx(u(x,t)) + α*Dx2(u(x,t)) + β*Dx3(u(x,t)) + γ*Dx4(u(x,t)) ~ 0
+    @test DiffEqOperators.differential_order(eq.lhs, x.val) == Set([4, 3, 2, 1])
+end
+
+# mixed terms DxDy, DxxDyy
+# Sum of terms Dx, Dxx, Dxxx
+# SUm of terms with multivar
+# ks equation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ if GROUP == "All" || GROUP == "MOLFiniteDifference"
     #@time @safetestset "MOLFiniteDifference Interface: Linear Convection" begin include("MOL/MOL_1D_Linear_Convection.jl") end
     @time @safetestset "MOLFiniteDifference Interface: 1D Diffusion" begin include("MOL/MOL_1D_Diffusion.jl") end
     @time @safetestset "MOLFiniteDifference Interface: 2D Diffusion" begin include("MOL/MOL_2D_Diffusion.jl") end
+    @time @safetestset "MOLFiniteDifference Interface: 1D HigherOrder" begin include("MOL/MOL_1D_HigherOrder.jl") end
 end
 
 if GROUP == "All" || GROUP == "Misc"


### PR DESCRIPTION
This is an attempt to resolve #353. The current solution determines the order of each term in the equation and enumerates those orders to create symbolic substitution rules for centered finite differences.