### PR TITLE
Specify type for dx in difference constructors

### DIFF
--- a/docs/src/operators/derivative_operators.md
+++ b/docs/src/operators/derivative_operators.md
@@ -91,11 +91,11 @@ The constructors are as follows:
 
 ```julia
 CenteredDifference{N}(derivative_order::Int,
-                      approximation_order::Int, dx,
+                      approximation_order::Int, dx::Float,
                       len::Int, coeff_func=nothing)
 
 UpwindDifference{N}(derivative_order::Int,
-                    approximation_order::Int, dx
+                    approximation_order::Int, dx::Float
                     len::Int, coeff_func=nothing; offside::Int=0)
 ```
 

--- a/docs/src/operators/derivative_operators.md
+++ b/docs/src/operators/derivative_operators.md
@@ -91,11 +91,11 @@ The constructors are as follows:
 
 ```julia
 CenteredDifference{N}(derivative_order::Int,
-                      approximation_order::Int, dx::Float,
+                      approximation_order::Int, dx,
                       len::Int, coeff_func=nothing)
 
 UpwindDifference{N}(derivative_order::Int,
-                    approximation_order::Int, dx::Float
+                    approximation_order::Int, dx
                     len::Int, coeff_func=nothing; offside::Int=0)
 ```
 
@@ -107,7 +107,7 @@ The arguments are:
 - `approximation_order`: the order of the discretization in terms of O(dx^order).
 - `dx`: the spacing of the discretization. If `dx` is a `Number`, the operator
   is a uniform discretization. If `dx` is an array, then the operator is a
-  non-uniform discretization.
+  non-uniform discretization. Its type needs to match the one from the Array to be differentiated.
 - `len`: the length of the discretization in the direction of the operator.
 - `coeff_func`: An operational argument for a coefficient function `f(du,u,p,t)`
   which sets the coefficients of the operator. If `coeff_func` is a `Number`,


### PR DESCRIPTION
Only the type of `dx` was missing in the DiffEqOperators.jl documentation, which made it unclear if `dx` needs to be an `Int` or a `Float`.