### PR TITLE
reduced allocations for vcops and fixed loop orders

### DIFF
--- a/src/derivative_operators/vector_algebraic_operations.jl
+++ b/src/derivative_operators/vector_algebraic_operations.jl
@@ -35,10 +35,8 @@ function cross_product!(u::AbstractArray{T1,4},A::AbstractArray{T2,4},B::Abstrac
     
     (size(A) === size(B) && size(A) === size(u))|| throw(ArgumentError("Vectors must have the same shape"))
     s = size(u)
-    for p in 1:s[1],q in 1:s[2],r in 1:s[3]
-        for i in 1:3
-            u[p,q,r,i] = A[p,q,r,i%3 + 1]*B[p,q,r,(i+1)%3 + 1] - A[p,q,r,(i+1)%3 + 1]*B[p,q,r,i%3 + 1]
-        end
+    for i in 1:3, r in 1:s[3], q in 1:s[2], p in 1:s[1]
+        u[p,q,r,i] = A[p,q,r,i%3 + 1]*B[p,q,r,(i+1)%3 + 1] - A[p,q,r,(i+1)%3 + 1]*B[p,q,r,i%3 + 1]
     end
 end
 

--- a/src/derivative_operators/vector_calculus_operators.jl
+++ b/src/derivative_operators/vector_calculus_operators.jl
@@ -57,10 +57,7 @@ function *(A::GradientOperator{T},M::AbstractArray{T,N}) where {T<:Real,N}
 
     x_temp = zeros(T,size_x_temp...,N)
 
-    for L in A.ops
-        mul!(x_temp, false, L, M)
-    end
-
+    mul!(x_temp,false,A,M)
     return x_temp
 end
 
@@ -79,10 +76,7 @@ function *(A::DivergenceOperator{T},M::AbstractArray{T,N}) where {T<:Real, N}
 
     x_temp = zeros(T,size_x_temp...)
 
-    for L in A.ops
-        mul!(x_temp, true, L, M)
-    end
-
+    mul!(x_temp,true,A,M)
     return x_temp
 end
 

--- a/test/DerivativeOperators/curl_operator.jl
+++ b/test/DerivativeOperators/curl_operator.jl
@@ -9,7 +9,7 @@ using DiffEqOperators, Test
     
     u0 = zeros(Float64,length(x),length(y),length(z),3)
 
-    for i in 1:length(x), j in 1:length(y), k in 1:length(z)
+    for k in 1:length(z), j in 1:length(y), i in 1:length(x)
         u0[i,j,k,1] = y[j]^2 + z[k]^2
         u0[i,j,k,2] = x[i]^2 + z[k]^2
         u0[i,j,k,3] = x[i]^2 + y[j]^2
@@ -17,7 +17,7 @@ using DiffEqOperators, Test
     
     # Analytic Curl of the given vector given by u_analytic = 2(y-z) ê₁ + 2(z-x) ê₂  + 2(x-y) ê₃
     u_analytic = zeros(Float64,length(x)-2,length(y)-2,length(z)-2,3)
-    for i in 1:length(x)-2, j in 1:length(y)-2, k in 1:length(z)-2 
+    for k in 1:length(z)-2, j in 1:length(y)-2, i in 1:length(x)-2 
         u_analytic[i,j,k,1] = 2*(y[j+1] - z[k+1])
         u_analytic[i,j,k,2] = 2*(z[k+1] - x[i+1])
         u_analytic[i,j,k,3] = 2*(x[i+1] - y[j+1])

--- a/test/DerivativeOperators/divergence_operator.jl
+++ b/test/DerivativeOperators/divergence_operator.jl
@@ -1,13 +1,43 @@
 using DiffEqOperators, Test
 
+@testset "Divergence operation for a 2D Vector" begin
+    
+    # For testing the faster implementation for a 2D Vector
+    s = x, y = (-5:1.25:5, -5:1.25:5)
+    dx = dy = x[2] - x[1]
+    
+    # Vector u0 = (x^2) ê₁ + (y^2) ê₂
+    u0 = zeros(Float64,length(x),length(y),2)
+    for j in 1:length(y), i in 1:length(x)
+        u0[i,j,1] = x[i]^2
+        u0[i,j,2] = y[j]^2
+    end
+    
+    # Analytic Divergence of the given vector given by u_analytic = 2x + 2y
+    
+    u_analytic = zeros(Float64,size(u0)[1:end-1].-2)
+    for j in 1:length(y)-2, i in 1:length(x)-2
+        u_analytic[i,j] = 2*x[i+1] + 2*y[j+1]
+    end
+    
+    A = Divergence(4,(dx,dy),size(u0)[1:end-1].-2)
+    
+    u = A*u0
+    
+    for I in CartesianIndices(u)
+        @test u[I] ≈ u_analytic[I] atol = 1e-3
+    end    
+end
+
 @testset "Divergence operation for a 3D Vector" begin
     
+    # For testing the faster implementation for a 3D Vector
     s = x, y, z = (-5:1.25:5, -5:1.25:5, -5:1.25:5)
     dx = dy = dz = x[2] - x[1]
     
     # Vector u0 = (x^2 + y^2) ê₁ + (y^2 + z^2) ê₂  + (x^2 + z^2) ê₃
     u0 = zeros(Float64,length(x),length(y),length(z),3)
-    for i in 1:length(x), j in 1:length(y), k in 1:length(z)
+    for k in 1:length(z), j in 1:length(y), i in 1:length(x)
         u0[i,j,k,1] = x[i]^2 + y[j]^2
         u0[i,j,k,2] = y[j]^2 + z[k]^2
         u0[i,j,k,3] = x[i]^2 + z[k]^2
@@ -15,8 +45,8 @@ using DiffEqOperators, Test
     
     # Analytic Divergence of the given vector given by u_analytic = 2x + 2y + 2z
     
-    u_analytic = zeros(Float64,size(u0).-2)
-    for i in 1:length(x)-2, j in 1:length(y)-2, k in 1:length(z)-2
+    u_analytic = zeros(Float64,size(u0)[1:end-1].-2)
+    for k in 1:length(z)-2, j in 1:length(y)-2, i in 1:length(x)-2
         u_analytic[i,j,k] = 2*x[i+1] + 2*y[j+1] + 2*z[k+1]
     end
     
@@ -47,4 +77,35 @@ using DiffEqOperators, Test
     for I in CartesianIndices(u)
         @test u[I] ≈ u_analytic[I] atol=1e-3
     end
+end
+
+@testset "Divergence operation for a 4D Vector" begin
+    
+    # For Testing the fallback implementation
+    s = x, y, z, w = (-5:1.25:5, -5:1.25:5, -5:1.25:5, -5:1.25:5)
+    dx = dy = dz = dw = x[2] - x[1]
+    
+    # Vector u0 = (x^2 + y^2) ê₁ + (y^2 + z^2) ê₂  + (z^2 + w^2) ê₃ + (x^2 + w^2) ê₄
+    u0 = zeros(Float64,length(x),length(y),length(z),length(w),4)
+    for l in 1:length(w), k in 1:length(z), j in 1:length(y), i in 1:length(x)
+        u0[i,j,k,l,1] = x[i]^2 + y[j]^2
+        u0[i,j,k,l,2] = y[j]^2 + z[k]^2
+        u0[i,j,k,l,3] = z[k]^2 + w[l]^2
+        u0[i,j,k,l,4] = x[i]^2 + w[l]^2
+    end
+    
+    # Analytic Divergence of the given vector given by u_analytic = 2x + 2y + 2z + 2w
+    
+    u_analytic = zeros(Float64,size(u0)[1:end-1].-2)
+    for l in 1:length(w)-2, k in 1:length(z)-2, j in 1:length(y)-2, i in 1:length(x)-2
+        u_analytic[i,j,k,l] = 2*x[i+1] + 2*y[j+1] + 2*z[k+1] + 2*w[l+1]
+    end
+    
+    A = Divergence(4,(dx,dy,dz,dw),size(u0)[1:end-1].-2)
+    
+    u = A*u0
+    
+    for I in CartesianIndices(u)
+        @test u[I] ≈ u_analytic[I] atol = 1e-3
+    end    
 end

--- a/test/DerivativeOperators/gradient_operator.jl
+++ b/test/DerivativeOperators/gradient_operator.jl
@@ -1,7 +1,36 @@
 using DiffEqOperators, Test
 
+@testset "Gradient Operation on a 2-dimensional function" begin
+    
+    # For testing the faster implementation for a 2-dim function
+    s = x, y = (-5:1.25:5, -5:1.25:5)
+    dx = dy = x[2] - x[1]
+
+    f(x::T, y::T) where T = x^2 + y^2
+
+    u0 = [f(X, Y) for X in x, Y in y]
+
+    # Analytic Gradient of the function is given by u_analytic = 2x ê₁ + 2y ê₂
+
+    u_analytic = zeros(Float64,(size(u0).-2)...,2)
+
+    for j in 1:length(y)-2, i in 1:length(x)-2
+        u_analytic[i,j,1] = 2*x[i+1]
+        u_analytic[i,j,2] = 2*y[j+1]
+    end
+
+    A = Gradient(4,(dx,dy),size(u0).-2)
+
+    u = A*u0
+    
+    for I in CartesianIndices(u)
+        @test u[I] ≈ u_analytic[I] atol=1e-3
+    end
+end
+
 @testset "Gradient Operation on a 3-dimensional function" begin
 
+    # For testing the faster implementation for a 3-dim function
     s = x, y, z = (-5:1.25:5, -5:1.25:5, -5:1.25:5)
     dx = dy = dz = x[2] - x[1]
 
@@ -13,7 +42,7 @@ using DiffEqOperators, Test
 
     u_analytic = zeros(Float64,(size(u0).-2)...,3)
 
-    for i in 1:length(x)-2, j in 1:length(y)-2, k in 1:length(z)-2
+    for k in 1:length(z)-2, j in 1:length(y)-2, i in 1:length(x)-2
         u_analytic[i,j,k,1] = 2*x[i+1]
         u_analytic[i,j,k,2] = 2*y[j+1]
         u_analytic[i,j,k,3] = 2*z[k+1]
@@ -39,6 +68,37 @@ using DiffEqOperators, Test
     dx = dy = dz = 1.25*ones(10)
 
     A = Gradient(4,(dx,dy,dz),size(u0).-2)
+
+    u = A*u0
+
+    for I in CartesianIndices(u)
+        @test u[I] ≈ u_analytic[I] atol=1e-3
+    end
+end
+
+@testset "Gradient Operation on a 4-dimensional function" begin
+
+    # For Testing the fallback implementation
+
+    s = x, y, z, w = (-5:1.25:5, -5:1.25:5, -5:1.25:5, -5:1.25:5)
+    dx = dy = dz = dw = x[2] - x[1]
+
+    f(x::T, y::T, z::T, w::T) where T = x^2 + y^2 + z^2 + w^2
+
+    u0 = [f(X, Y, Z, W) for X in x, Y in y, Z in z, W in w]
+
+    # Analytic Gradient of the function is given by u_analytic = 2x ê₁ + 2y ê₂  + 2z ê₃ + 2w ê₄
+
+    u_analytic = zeros(Float64,(size(u0).-2)...,4)
+
+    for l in 1:length(w)-2, k in 1:length(z)-2, j in 1:length(y)-2, i in 1:length(x)-2
+        u_analytic[i,j,k,l,1] = 2*x[i+1]
+        u_analytic[i,j,k,l,2] = 2*y[j+1]
+        u_analytic[i,j,k,l,3] = 2*z[k+1]
+        u_analytic[i,j,k,l,4] = 2*w[l+1]
+    end
+
+    A = Gradient(4,(dx,dy,dz,dw),size(u0).-2)
 
     u = A*u0
 

--- a/test/DerivativeOperators/vector_algebraic_operations.jl
+++ b/test/DerivativeOperators/vector_algebraic_operations.jl
@@ -9,14 +9,14 @@ using DiffEqOperators, Test
 
     u0 = zeros(Float64,length(x),length(y),length(z),3)
 
-    for i in 1:length(x), j in 1:length(y), k in 1:length(z)
+    for k in 1:length(z), j in 1:length(y), i in 1:length(x)
         u0[i,j,k,1] = x[i]^2
         u0[i,j,k,2] = y[j]^2
         u0[i,j,k,3] = z[k]^2
     end
 
     u1 = zeros(Float64,length(x),length(y),length(z),3)
-    for i in 1:length(x), j in 1:length(y), k in 1:length(z)
+    for k in 1:length(z), j in 1:length(y), i in 1:length(x)
         u1[i,j,k,1] = x[i]
         u1[i,j,k,2] = y[j]
         u1[i,j,k,3] = z[k]
@@ -41,7 +41,7 @@ using DiffEqOperators, Test
     # Analytic cross u0 × u1 is given by u_analytic2 = yz(y-z)ê₁ + xz(z-x)ê₂ + xy(x-y)ê₃
     
     u_analytic2 = zeros(Float64,size(u0))
-    for i in 1:length(x), j in 1:length(y), k in 1:length(z)
+    for k in 1:length(z), j in 1:length(y), i in 1:length(x)
         u_analytic2[i,j,k,1] = y[j]*z[k]*(y[j]-z[k])
         u_analytic2[i,j,k,2] = x[i]*z[k]*(z[k]-x[i])
         u_analytic2[i,j,k,3] = x[i]*y[j]*(x[i]-y[j])


### PR DESCRIPTION
Written new convolutions for reducing allocations in `Gradient` and `Divergence` treating 2D & 3D functions/vectors as special cases since they are the ones most widely used.
Loop ordering has also been fixed wherever required.