### PR TITLE
WIP: 2nd order pde

### DIFF
--- a/src/MOLFiniteDifference/MOL_discretization.jl
+++ b/src/MOLFiniteDifference/MOL_discretization.jl
@@ -140,10 +140,7 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
 
             bclocs = map(e->substitute.(indvars,e),edgevals) # location of the boundary conditions e.g. (t,0.0,y)
             edgemaps = Dict(bclocs .=> [spacevals[e...] for e in edges])
-            initmaps = depvars
-            if t != nothing
-                initmaps = substitute.(depvars,[t=>tspan[1]])
-            end
+            initmaps = substitute.(depvars,[t=>tspan[1]])
 
             # Generate map from variable (e.g. u(t,0)) to discretized variable (e.g. u₁(t))
             subvar(depvar) = substitute.((depvar,),edgevals)
@@ -187,13 +184,31 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
             # Generate initial conditions and bc equations
             for bc in pdesys.bcs
                 bcdepvar = first(get_depvars(bc.lhs, depvar_ops))
+                # Make sure the bcdepvar is one of the depvars
                 if any(u->isequal(operation(u),operation(bcdepvar)),depvars)
-                    if t != nothing && operation(bc.lhs) isa Sym && !any(x -> isequal(x, t.val), arguments(bc.lhs))
+                    # Check whether the bc is an initial condition
+                    is_ic = false
+                    if operation(bc.lhs) isa Sym && !any(x -> isequal(x, t.val), arguments(bc.lhs))
+                        # Look for u(t,0) case
+                        depvar = bc.lhs # e.g. u(t,0)
+                        bcop = identity
+                        is_ic = true
+                    elseif operation(bc.lhs) isa Differential
+                        # Look for Dt(u(t,0)) case
+                        depvar = arguments(bc.lhs)[1] # e.g. u(t,0)
+                        if operation(depvar) isa Sym && !any(x -> isequal(x, t.val), arguments(depvar))
+                            bcop = operation(bc.lhs) # e.g. Dt
+                            is_ic = true
+                        end
+                    end
+                    if t != nothing && is_ic
                         # initial condition
-                        # Assume in the form `u(...) ~ ...` for now
-                        i = findfirst(isequal(bc.lhs),initmaps)
+                        # Assume in the form `u(...) ~ ...` or `Dt(u(...)) ~ ...` for now
+                        # find the index of the depvar
+                        i = findfirst(isequal(depvar),initmaps)
                         if i !== nothing
-                            push!(u0,vec(depvarsdisc[i] .=> substitute.((bc.rhs,),gridvals)))
+                            # bcop is identity for u(...) and Dt for Dt(u(...))
+                            push!(u0,vec(bcop.(depvarsdisc[i]) .=> substitute.((bc.rhs,),gridvals)))
                         end
                     else
                         # Algebraic equations for BCs
@@ -207,7 +222,7 @@ function SciMLBase.symbolic_discretize(pdesys::ModelingToolkit.PDESystem,discret
                             # Replace symbol in the bc lhs with the spatial discretized term
                             lhs = substitute(lhs,depvarbcmaps[i])
                             rhs = substitute.((bc.rhs,),edgemaps[bcargs])
-                            lhs = lhs isa Vector ? lhs : [lhs] # handle 1D
+                            lhs = lhs isa Array ? lhs : [lhs] # handle 1D
                             push!(bceqs,lhs .~ rhs)
                         end
                     end
@@ -375,6 +390,8 @@ end
 
 function SciMLBase.discretize(pdesys::ModelingToolkit.PDESystem,discretization::DiffEqOperators.MOLFiniteDifference)
     sys, tspan = SciMLBase.symbolic_discretize(pdesys,discretization)
+    # Lower order for higher-order ODEs (e.g. wave equation)
+    sys = ode_order_lowering(sys)
     if tspan == nothing
         return prob = NonlinearProblem(sys, ones(length(sys.states)))
     else

--- a/test/MOL/MOL_1D_Wave.jl
+++ b/test/MOL/MOL_1D_Wave.jl
@@ -44,11 +44,12 @@ using ModelingToolkit: Differential
     t_sol = sol.t
 
     # Test against exact solution
-    for i in 1:length(sol)
+    # for i in 1:length(sol)
+    i = 10
         exact = u_exact(x_sol, t_sol[i])
         # non-differential states only (ode_sys_lowering creates additional differential states)
         u_approx = sol.u[i][1:28]
         @test all(isapprox.(u_approx, exact, atol=0.01))
-    end
+    # end
 # end
 

--- a/test/MOL/MOL_1D_Wave.jl
+++ b/test/MOL/MOL_1D_Wave.jl
@@ -50,29 +50,4 @@ using ModelingToolkit: Differential
         @test all(isapprox.(u_approx, exact, atol=0.01))
     end
 # end
-using ModelingToolkit, OrdinaryDiffEq
 
-@parameters t σ ρ β
-@variables x(t) y(t) z(t)
-D = Differential(t)
-
-eqs = [D(D(x)) ~ σ*(y-x),
-       D(y) ~ x*(ρ-z)-y,
-       D(z) ~ x*y - β*z]
-
-sys = ODESystem(eqs)
-sys = ode_order_lowering(sys)
-
-u0 = [D(x) => 2.0,
-      x => 1.0,
-      y => 0.0,
-      z => 0.0]
-
-p  = [σ => 28.0,
-      ρ => 10.0,
-      β => 8/3]
-
-tspan = (0.0,100.0)
-prob = ODEProblem(sys,u0,tspan,p,jac=true)
-sol = solve(prob,Tsit5())
-using Plots; plot(sol,vars=(x,y))

--- a/test/MOL/MOL_1D_Wave.jl
+++ b/test/MOL/MOL_1D_Wave.jl
@@ -1,0 +1,78 @@
+# 1D wave equation problems
+
+# Packages and inclusions
+using ModelingToolkit,DiffEqOperators,LinearAlgebra,Test,OrdinaryDiffEq, DomainSets
+using ModelingToolkit: Differential
+
+# Tests
+# @testset "Test 00: Dtt(u(t,x)) ~ Dxx(u(t,x))" begin
+    # Method of Manufactured Solutions
+    u_exact = (x,t) -> exp.(-t) * cos.(x)
+
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dtt = Differential(t)^2
+    Dxx = Differential(x)^2
+
+    # 1D PDE and boundary conditions
+    eq  = Dtt(u(t,x)) ~ -Dxx(u(t,x))
+    bcs = [u(0,x) ~ cos(x),
+           Dt(u(0,x)) ~ -cos(x),
+           u(t,0) ~ exp(-t),
+           u(t,Float64(π)) ~ -exp(-t)]
+
+    # Space and time domains
+    domains = [t ∈ Interval(0.0,1.0),
+               x ∈ Interval(0.0,Float64(π))]
+
+    # PDE system
+    pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
+
+    # Method of lines discretization
+    dx = range(0.0,Float64(π),length=30)
+    order = 2
+    discretization = MOLFiniteDifference([x=>dx],t)
+
+    # Convert the PDE problem into an ODE problem
+    prob = discretize(pdesys,discretization)
+    sys, tspan = SciMLBase.symbolic_discretize(pdesys,discretization)
+    # Solve ODE problem
+    sol = solve(prob,Tsit5(),saveat=0.1)
+    x_sol = dx[2:end-1]
+    t_sol = sol.t
+
+    # Test against exact solution
+    for i in 1:length(sol)
+        exact = u_exact(x_sol, t_sol[i])
+        u_approx = sol.u[i]
+        @test all(isapprox.(u_approx, exact, atol=0.01))
+    end
+# end
+using ModelingToolkit, OrdinaryDiffEq
+
+@parameters t σ ρ β
+@variables x(t) y(t) z(t)
+D = Differential(t)
+
+eqs = [D(D(x)) ~ σ*(y-x),
+       D(y) ~ x*(ρ-z)-y,
+       D(z) ~ x*y - β*z]
+
+sys = ODESystem(eqs)
+sys = ode_order_lowering(sys)
+
+u0 = [D(x) => 2.0,
+      x => 1.0,
+      y => 0.0,
+      z => 0.0]
+
+p  = [σ => 28.0,
+      ρ => 10.0,
+      β => 8/3]
+
+tspan = (0.0,100.0)
+prob = ODEProblem(sys,u0,tspan,p,jac=true)
+sol = solve(prob,Tsit5())
+using Plots; plot(sol,vars=(x,y))

--- a/test/MOL/MOL_1D_Wave.jl
+++ b/test/MOL/MOL_1D_Wave.jl
@@ -46,7 +46,8 @@ using ModelingToolkit: Differential
     # Test against exact solution
     for i in 1:length(sol)
         exact = u_exact(x_sol, t_sol[i])
-        u_approx = sol.u[i]
+        # non-differential states only (ode_sys_lowering creates additional differential states)
+        u_approx = sol.u[i][1:28]
         @test all(isapprox.(u_approx, exact, atol=0.01))
     end
 # end


### PR DESCRIPTION
Trying to add functionality for 2nd order PDE such as the wave equation (inspired by #421 )
Not obvious why the test is failing, am I missing something obvious? Equations look sensible:
```
julia> equations(sys)
30-element Vector{Equation}:
 Differential(t)(Differential(t)(u₂(t))) ~ -(85.21111544320605u₁(t) + 85.21111544320605u₃(t) - (170.4222308864121u₂(t)))
 Differential(t)(Differential(t)(u₃(t))) ~ -(85.21111544320605u₂(t) + 85.21111544320603u₄(t) - (170.42223088641208u₃(t)))
 Differential(t)(Differential(t)(u₄(t))) ~ -(85.21111544320605u₃(t) + 85.21111544320608u₅(t) - (170.42223088641214u₄(t)))
 Differential(t)(Differential(t)(u₅(t))) ~ -(85.21111544320608u₄(t) + 85.2111154432061u₆(t) - (170.4222308864122u₅(t)))
 Differential(t)(Differential(t)(u₆(t))) ~ -(85.21111544320607u₅(t) + 85.21111544320603u₇(t) - (170.42223088641208u₆(t)))
 Differential(t)(Differential(t)(u₇(t))) ~ -(85.21111544320604u₆(t) + 85.21111544320613u₈(t) - (170.42223088641217u₇(t)))
 Differential(t)(Differential(t)(u₈(t))) ~ -(85.21111544320614u₇(t) + 85.21111544320604u₉(t) - (170.4222308864122u₈(t)))
 Differential(t)(Differential(t)(u₉(t))) ~ -(85.21111544320613u₁₀(t) + 85.21111544320604u₈(t) - (170.42223088641217u₉(t)))
 ⋮
 Differential(t)(Differential(t)(u₂₄(t))) ~ -(85.211115443206u₂₃(t) + 85.211115443206u₂₅(t) - (170.422230886412u₂₄(t)))
 Differential(t)(Differential(t)(u₂₅(t))) ~ -(85.21111544320617u₂₄(t) + 85.21111544320651u₂₆(t) - (170.42223088641268u₂₅(t)))
 Differential(t)(Differential(t)(u₂₆(t))) ~ -(85.21111544320652u₂₅(t) + 85.21111544320618u₂₇(t) - (170.4222308864127u₂₆(t)))
 Differential(t)(Differential(t)(u₂₇(t))) ~ -(85.211115443206u₂₆(t) + 85.211115443206u₂₈(t) - (170.422230886412u₂₇(t)))
 Differential(t)(Differential(t)(u₂₈(t))) ~ -(85.211115443206u₂₇(t) + 85.211115443206u₂₉(t) - (170.422230886412u₂₈(t)))
 Differential(t)(Differential(t)(u₂₉(t))) ~ -(85.211115443206u₂₈(t) + 85.211115443206u₃₀(t) - (170.422230886412u₂₉(t)))
 u₁(t) ~ exp(-t)
 u₃₀(t) ~ -exp(-t)
```

```
julia> equations(ode_order_lowering(sys))
58-element Vector{Equation}:
 Differential(t)(u₂ˍt(t)) ~ -(85.21111544320605u₁(t) + 85.21111544320605u₃(t) - (170.4222308864121u₂(t)))
 Differential(t)(u₃ˍt(t)) ~ -(85.21111544320605u₂(t) + 85.21111544320603u₄(t) - (170.42223088641208u₃(t)))
 Differential(t)(u₄ˍt(t)) ~ -(85.21111544320605u₃(t) + 85.21111544320608u₅(t) - (170.42223088641214u₄(t)))
 Differential(t)(u₅ˍt(t)) ~ -(85.21111544320608u₄(t) + 85.2111154432061u₆(t) - (170.4222308864122u₅(t)))
 Differential(t)(u₆ˍt(t)) ~ -(85.21111544320607u₅(t) + 85.21111544320603u₇(t) - (170.42223088641208u₆(t)))
 Differential(t)(u₇ˍt(t)) ~ -(85.21111544320604u₆(t) + 85.21111544320613u₈(t) - (170.42223088641217u₇(t)))
 Differential(t)(u₈ˍt(t)) ~ -(85.21111544320614u₇(t) + 85.21111544320604u₉(t) - (170.4222308864122u₈(t)))
 Differential(t)(u₉ˍt(t)) ~ -(85.21111544320613u₁₀(t) + 85.21111544320604u₈(t) - (170.42223088641217u₉(t)))
 ⋮
 Differential(t)(u₂₄(t)) ~ u₂₄ˍt(t)
 Differential(t)(u₂₅(t)) ~ u₂₅ˍt(t)
 Differential(t)(u₂₆(t)) ~ u₂₆ˍt(t)
 Differential(t)(u₂₇(t)) ~ u₂₇ˍt(t)
 Differential(t)(u₂₈(t)) ~ u₂₈ˍt(t)
 Differential(t)(u₂₉(t)) ~ u₂₉ˍt(t)
 u₁(t) ~ exp(-t)
 u₃₀(t) ~ -exp(-t)
```