### PR TITLE
fornberg(2020) weights based on hermite-based finite difference

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -8,15 +8,18 @@ CenteredDifference
 
 
 @doc """
-    calculate_weights(n::Int, x₀::Real, x::Vector)
+    calculate_weights(n::Int, x₀::Real, x::Vector; dfdx::Bool = false)
 
-Return a vector `c` such that `c⋅f.(x)` approximates ``f^{(n)}(x₀)`` for a smooth `f`.
+(Default kwarg `dfdx == false`)Return a vector `c` such that `c⋅f.(x)` approximates ``f^{(n)}(x₀)`` for a smooth `f`.
+(kwarg `dfdx == true`)Returnvectors `d` and `e` such that `d⋅f.(x) + e⋅f'.(x)` approximates ``f^{(n)}(x₀)`` for a smooth `f`.
 
 The points `x` need not be evenly spaced.
 
 The stencil `c` has the highest approximation order possible given values of `f` at `length(x)` points. More precisely, if `x` has length `m`, there is a function `g` such that ``g(y) = f(y) + O(y-x₀)^{m-n+?}`` and ``c⋅f.(x) = g'(x₀)``.
+The stencil `d` and `e` has the highest approximation order possible given values of `f` at `length(x)` points. More precisely, if `x` has length `m`, there is a function `g` such that ``g(y) = f(y) + O(y-x₀)^{m-n+?}`` and ``d⋅f.(x) + e⋅f'.(x) = g'(x₀)``.
 
-The algorithm is due to [Fornberg](https://doi.org/10.1090/S0025-5718-1988-0935077-0), with a [modification](http://epubs.siam.org/doi/pdf/10.1137/S0036144596322507) to improve stability.
+The algorithm is due to [Fornberg, 1988](https://doi.org/10.1090/S0025-5718-1988-0935077-0), with a [modification](http://epubs.siam.org/doi/pdf/10.1137/S0036144596322507) to improve stability,
+& [Fornberg, 2020](https://doi.org/10.1093/imanum/draa006)
 """
 calculate_weights
 

--- a/test/Misc/utils.jl
+++ b/test/Misc/utils.jl
@@ -9,6 +9,34 @@ using ModelingToolkit
     @test DiffEqOperators.perpsize(zeros(2,2,3,2), 3) == (2, 2, 2)
 end
 
+@testset "finite-difference weights from fornberg(1988) & fornberg(2020)" begin
+    order = 2; z = 0.0; x = [-1, 0, 1.0];
+    @test DiffEqOperators.calculate_weights(order, z, x) == [1,-2,1]  # central difference of second-derivative with unit-step
+
+    order = 1; z = 0.0; x = [-1., 1.0];
+    @test DiffEqOperators.calculate_weights(order, z, x) == [-0.5,0.5] # central difference of first-derivative with unit step
+
+    order = 1; z = 0.0; x = [0, 1];
+    @test DiffEqOperators.calculate_weights(order, z, x) == [-1, 1] # forward difference
+
+    order = 1; z = 1.0; x = [0, 1];
+    @test DiffEqOperators.calculate_weights(order, z, x) == [-1, 1] # backward difference
+
+    # forward-diff of third derivative with order of accuracy == 3
+    order = 3; z = 0.0; x = [0,1,2,3,4,5]
+    @test DiffEqOperators.calculate_weights(order, z, x) == [-17/4,	71/4	,−59/2,	49/2,	−41/4,	7/4]
+    
+    order = 3; z = 0.0; x = collect(-3:3)
+    d, e = DiffEqOperators.calculate_weights(order, z, x;dfdx = true)
+    @test d ≈ [-167/18000, -963/2000, -171/16,0,171/16,963/2000,167/18000]
+    @test e ≈ [-1/600,-27/200,-27/8,-49/3,-27/8,-27/200,-1/600]
+    
+    order = 3; z = 0.0; x = collect(-4:4)
+    d, e = DiffEqOperators.calculate_weights(order, z, x;dfdx = true)
+    @test d ≈ [-2493/5488000, -12944/385875, -87/125 ,-1392/125,0,1392/125,87/125,12944/385875,2493/5488000]
+    @test e ≈ [-3/39200,-32/3675,-6/25,-96/25,-205/12, -96/25, -6/25,-32/3675,-3/39200]
+end
+
 @testset "count differentials 1D" begin
     @parameters t x
     @variables u(..)


### PR DESCRIPTION
As per discussion earlier today with @ChrisRackauckas  on slack, this PR extends `DiffEqOperators.calculate_weights` function to include recent algorithm of hermite-based finite difference weights by [fornberg(2020)](https://www.colorado.edu/amath/sites/default/files/attached-files/2020_f_hermite-fd_ima_j_num_anal.pdf)

- The original fornberg(1988) algorithm is invoked by default !
- To invoke hermite-based FD fornberg(2020), one just needs to pass kwarg `dfdx = true` to the `DiffEqOperators.calculate_weights` function, thus, returning the weights/stencil for function values and weights/stencil for the first-derivative values  of the function respectively.

This algorithm uses same matrix of weights generated from fornberg(1988) algorithm to generate new set of weights.

Corresponding tests for both cases are added, and docstrings are also updated.

I do not yet know how to use these weights for MOL/discretisation and other boundary conditions functions etc, hence have kept default . I will try to cover those next time.