### PR TITLE
Specialize `sparse` for various operators

### DIFF
--- a/src/derivative_operators/derivative_operator_functions.jl
+++ b/src/derivative_operators/derivative_operator_functions.jl
@@ -183,7 +183,7 @@ function LinearAlgebra.mul!(x_temp::AbstractArray{T,2}, A::AbstractDiffEqComposi
     opsA = DerivativeOperator[]
     opsB = DerivativeOperator[]
     for L in A.ops
-        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) == false && L.dx isa Number
+        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) === false && L.dx isa Number
             push!(opsA, L)
         else
             push!(opsB,L)
@@ -416,7 +416,7 @@ function LinearAlgebra.mul!(x_temp::AbstractArray{T,3}, A::AbstractDiffEqComposi
     opsA = DerivativeOperator[]
     opsB = DerivativeOperator[]
     for L in A.ops
-        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) == false && L.dx isa Number
+        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) === false && L.dx isa Number
             push!(opsA, L)
         else
             push!(opsB,L)

--- a/src/derivative_operators/derivative_operator_functions.jl
+++ b/src/derivative_operators/derivative_operator_functions.jl
@@ -183,7 +183,7 @@ function LinearAlgebra.mul!(x_temp::AbstractArray{T,2}, A::AbstractDiffEqComposi
     opsA = DerivativeOperator[]
     opsB = DerivativeOperator[]
     for L in A.ops
-        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) === false && L.dx isa Number
+        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) == false && L.dx isa Number
             push!(opsA, L)
         else
             push!(opsB,L)
@@ -416,7 +416,7 @@ function LinearAlgebra.mul!(x_temp::AbstractArray{T,3}, A::AbstractDiffEqComposi
     opsA = DerivativeOperator[]
     opsB = DerivativeOperator[]
     for L in A.ops
-        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) === false && L.dx isa Number
+        if (L.coefficients isa Number || L.coefficients === nothing) && use_winding(L) == false && L.dx isa Number
             push!(opsA, L)
         else
             push!(opsB,L)

--- a/test/DerivativeOperators/composite_operators_interface.jl
+++ b/test/DerivativeOperators/composite_operators_interface.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra, Random, DiffEqOperators
+using Test, LinearAlgebra, Random, SparseArrays, DiffEqOperators
 using DiffEqBase
 using DiffEqBase: isconstant
 using DiffEqOperators: DiffEqScaledOperator, DiffEqOperatorCombination, DiffEqOperatorComposition
@@ -22,6 +22,8 @@ using DiffEqOperators: DiffEqScaledOperator, DiffEqOperatorCombination, DiffEqOp
   @test opnorm(L) ≈ opnorm(Lfull)
   @test size(L) == size(Lfull)
   @test L[1,2] ≈ Lfull[1,2]
+  Lsparse = sparse(L)
+  @test Lsparse == Lfull
   u = [1.0, 2.0]; du = zeros(2)
   @test L * u ≈ Lfull * u
   mul!(du, L, u); @test du ≈ Lfull * u

--- a/test/DerivativeOperators/generic_operator_validation.jl
+++ b/test/DerivativeOperators/generic_operator_validation.jl
@@ -14,6 +14,8 @@ for dor in 1:4, aor in 2:2:6
     Dr = CenteredDifference(dor,aor,dx[1],length(x)-2)
     Dir = CenteredDifference(dor,aor,dx,length(x)-2)
 
+    @test sparse(Dr)==Array(Dr)
+
     @test sparse(Dr)≈sparse(Dir)
     @test Array(Dr)≈Array(Dir)
 


### PR DESCRIPTION
This should make it more efficient to create sparse matrix representations for difference operators.

Closes https://github.com/SciML/DiffEqOperators.jl/issues/392.